### PR TITLE
Claude設定ファイルをdotfilesで管理する

### DIFF
--- a/claude/commands/create-pr.md
+++ b/claude/commands/create-pr.md
@@ -1,0 +1,36 @@
+---
+description: PRを自動作成する（タイトル・本文をコミットから自動生成）
+argument-hint: [base-branch]
+allowed-tools: Bash
+---
+
+以下の手順でGitHub PRを作成してください。
+
+## 手順
+
+1. ベースブランチを確認する（引数 `$ARGUMENTS` が指定されていれば使用、なければ `main`）
+
+2. 以下のコマンドで情報を収集する：
+   - `git branch --show-current` で現在のブランチを確認
+   - `git log <base-branch>...HEAD --oneline` でコミット一覧を取得
+   - `git diff <base-branch>...HEAD --stat` でdiffサマリーを取得
+   - `git diff <base-branch>...HEAD` でdiff全文を取得
+
+3. 収集した情報を元に以下を生成する：
+   - **PRタイトル**: 変更内容を簡潔に表す日本語タイトル（70文字以内）
+   - **PR本文**: 以下のフォーマットで作成
+     ```
+     ## Summary
+     - 変更内容の箇条書き（1〜3項目）
+
+     ## Test plan
+     - テスト・確認手順の箇条書き
+
+     🤖 Generated with [Claude Code](https://claude.com/claude-code)
+     ```
+
+4. `git push -u origin <current-branch>` でブランチをリモートにプッシュする
+
+5. `gh pr create --base <base-branch> --title "<タイトル>" --body "<本文>"` でPRを作成する
+
+6. 作成されたPRのURLを表示する

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true
+  }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -103,6 +103,10 @@ main() {
     # Zsh
     create_symlink "$DOTFILES_DIR/zsh/.zshrc" "$HOME/.zshrc"
 
+    # Claude Code
+    create_symlink "$DOTFILES_DIR/claude/settings.json" "$HOME/.claude/settings.json"
+    create_symlink "$DOTFILES_DIR/claude/commands" "$HOME/.claude/commands"
+
     echo ""
     echo "========================================"
     print_success "セットアップ完了!"


### PR DESCRIPTION
## Summary
- `~/.claude/settings.json` と `~/.claude/commands/` をdotfilesリポジトリで管理するためのファイルを追加
- `setup.sh` にClaudeのシンボリックリンク作成処理を追加
- カスタムコマンド `/create-pr` をdotfilesに含め、Git管理下に置く

## Test plan
- `setup.sh` を実行して `~/.claude/settings.json` と `~/.claude/commands` がdotfilesへのシンボリックリンクになっていることを確認
- Claude Codeで `/create-pr` カスタムコマンドが使えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)