### PR TITLE
WeztermとNeo-treeの表示設定を改善

### DIFF
--- a/nvim/lua/plugins/neo-tree.lua
+++ b/nvim/lua/plugins/neo-tree.lua
@@ -18,6 +18,7 @@ return {
         follow_current_file = {
           enabled = true,
         },
+        use_libuv_file_watcher = true,
         window = {
           mappings = {
             ["<leader>yp"] = function(state)

--- a/wezterm/appearance.lua
+++ b/wezterm/appearance.lua
@@ -6,7 +6,8 @@ function M.apply(config, wezterm)
     "PlemolJP Console NF", -- 日本語フォールバック
   }
   config.font_size = 13.0
-  config.window_background_opacity = 1
+  config.line_height = 1.3
+  config.window_background_opacity = 0.9
   -- config.macos_window_background_blur = 10
   config.window_decorations = "RESIZE"
   config.window_frame = {


### PR DESCRIPTION
## 概要
- Weztermの行間・背景透過率を調整し、視認性を改善
- Neo-treeにファイルウォッチャーを追加し、ファイル変更を自動検知

## 背景・モチベーション
文字間隔・行間が狭く読みにくかったため調整。またNeo-treeのツリーが外部変更で自動更新されないため、ウォッチャーを有効化。

## 変更の詳細
- `wezterm/appearance.lua`: `line_height = 1.3`、`window_background_opacity = 0.9` を設定
- `nvim/lua/plugins/neo-tree.lua`: `use_libuv_file_watcher = true` を追加

## 動作確認
- [ ] Wezterm再起動後に行間・透過が反映されることを確認
- [ ] ファイル追加・削除時にNeo-treeが自動更新されることを確認

## 注意事項・補足
`use_libuv_file_watcher` はファイルシステム変更のみ検知。`git add` / `git commit` 等のgitインデックス変更は手動で `R` キーリフレッシュが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)