### PR TITLE
feat: vim-illuminateプラグインを追加（カーソル下の単語ハイライト）

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 | [toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim) | ターミナル | `plugins/toggleterm.lua` |
 | [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) | シンタックスハイライト | `plugins/treesitter.lua` |
 | [vim-moonfly-colors](https://github.com/bluz71/vim-moonfly-colors) | カラースキーム | `plugins/colorscheme.lua` |
+| [vim-illuminate](https://github.com/RRethy/vim-illuminate) | カーソル下の単語をハイライト | `plugins/illuminate.lua` |
 
 ## リポジトリ構成
 
@@ -66,7 +67,8 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 │       │   ├── tabset.lua
 │       │   ├── telescope.lua
 │       │   ├── toggleterm.lua
-│       │   └── treesitter.lua
+│       │   ├── treesitter.lua
+│       │   └── illuminate.lua
 │       └── ui/
 │           └── colorscheme.lua
 ├── wezterm/

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -30,6 +30,7 @@
   "telescope.nvim": { "branch": "master", "commit": "ad7d9580338354ccc136e5b8f0aa4f880434dcdc" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
   "vim-endwise": { "branch": "master", "commit": "4994afb0cdf956d9a665a14b9c834869e602c396" },
+  "vim-illuminate": { "branch": "master", "commit": "0d1e93684da00ab7c057410fecfc24f434698898" },
   "vim-rails": { "branch": "master", "commit": "b0a5c76f86ea214ade36ab0b811e730c3f0add67" },
   "vim-test": { "branch": "master", "commit": "931c6cfdd3069df52c4486b25200e4b10d0595c8" }
 }

--- a/nvim/lua/plugins/illuminate.lua
+++ b/nvim/lua/plugins/illuminate.lua
@@ -1,0 +1,30 @@
+return {
+  "RRethy/vim-illuminate",
+  event = { "BufReadPost", "BufNewFile" },
+  opts = {
+    providers = { "lsp", "treesitter", "regex" },
+    delay = 100,
+    under_cursor = true,
+    large_file_cutoff = 10000,
+    filetypes_denylist = {
+      "dirbuf",
+      "dirvish",
+      "fugitive",
+    },
+  },
+  config = function(_, opts)
+    require("illuminate").configure(opts)
+
+    -- 下線ではなく背景色でハイライト（VSCode スタイル）
+    vim.api.nvim_set_hl(0, "IlluminatedWordText", { bg = "#3a3a4a" })
+    vim.api.nvim_set_hl(0, "IlluminatedWordRead", { bg = "#3a3a4a" })
+    vim.api.nvim_set_hl(0, "IlluminatedWordWrite", { bg = "#3a3a4a" })
+
+    vim.keymap.set("n", "]]", function()
+      require("illuminate").goto_next_reference(false)
+    end, { desc = "次の参照へ" })
+    vim.keymap.set("n", "[[", function()
+      require("illuminate").goto_prev_reference(false)
+    end, { desc = "前の参照へ" })
+  end,
+}

--- a/nvim/lua/plugins/init.lua
+++ b/nvim/lua/plugins/init.lua
@@ -20,6 +20,7 @@ require("lazy").setup({
   { import = "plugins.dap" },
   { import = "plugins.swenv" },
   { import = "plugins.ruby" },
+  { import = "plugins.illuminate" },
 }, {
   checker = { enabled = false },
   change_detection = { notify = false },


### PR DESCRIPTION
## 概要

- `RRethy/vim-illuminate` を導入し、カーソル下の単語と同じ単語を自動ハイライトする機能を追加

## 背景・モチベーション

VSCode のようにカーソル位置の単語が画面全体でどこに存在するか視覚的に把握したい。

## 変更の詳細

- `nvim/lua/plugins/illuminate.lua` を新規作成
  - LSP → Tree-sitter → regex の優先順位でハイライト
  - 背景色スタイル（`#3a3a4a`）で VSCode 風の見た目に設定
  - `]]` / `[[` で次/前の参照へジャンプ可能
- `nvim/lua/plugins/init.lua` にプラグインの import を追加
- `README.md` のプラグイン一覧・ディレクトリ構成に illuminate を追記

## 動作確認

- [ ] Neovim 起動時に vim-illuminate が自動インストールされる
- [ ] 変数・関数名にカーソルを当てると同じ単語が背景色でハイライトされる
- [ ] `]]` / `[[` で参照間をジャンプできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)