### PR TITLE
feat: GitHub Actions CI と check スキルを追加

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -4,89 +4,82 @@ description: CIと同等のローカルチェックを実行する。shellcheck�
 tools: [Bash]
 ---
 
-以下の4つのチェックをすべて実行してください。1つが失敗しても残りを続行し、最後にサマリを表示してください。
-
-## チェック内容
-
-### 1. ShellCheck
+以下のスクリプトを1回の Bash ツール呼び出しで実行してください。
 
 ```bash
+total_failed=0
+
+# 1. ShellCheck
 if ! command -v shellcheck &>/dev/null; then
-  echo "[SKIP] shellcheck がインストールされていません"
+  shellcheck_result="[SKIP] ShellCheck"
+elif shellcheck setup.sh 2>&1; then
+  shellcheck_result="[PASS] ShellCheck"
 else
-  shellcheck setup.sh && echo "[PASS] ShellCheck" || echo "[FAIL] ShellCheck"
+  shellcheck_result="[FAIL] ShellCheck"
+  total_failed=$((total_failed + 1))
 fi
-```
 
-### 2. Luacheck
-
-```bash
+# 2. Luacheck
 if ! command -v luacheck &>/dev/null; then
-  echo "[SKIP] luacheck がインストールされていません"
+  luacheck_result="[SKIP] Luacheck"
+elif luacheck nvim/lua/ 2>&1; then
+  luacheck_result="[PASS] Luacheck"
 else
-  luacheck nvim/lua/ && echo "[PASS] Luacheck" || echo "[FAIL] Luacheck"
+  luacheck_result="[FAIL] Luacheck"
+  total_failed=$((total_failed + 1))
 fi
-```
 
-### 3. SKILL.md フロントマター検証
-
-```bash
-failed=0
+# 3. SKILL.md フロントマター検証
+skill_failed=0
 while IFS= read -r file; do
   if ! head -1 "$file" | grep -q '^---$'; then
     echo "  ERROR: フロントマターがありません: $file"
-    failed=1
+    skill_failed=1
     continue
   fi
   if ! awk '/^---$/{f++} f==1' "$file" | grep -q '^name:'; then
     echo "  ERROR: name フィールドがありません: $file"
-    failed=1
+    skill_failed=1
   fi
   if ! awk '/^---$/{f++} f==1' "$file" | grep -q '^description:'; then
     echo "  ERROR: description フィールドがありません: $file"
-    failed=1
+    skill_failed=1
   fi
 done < <(find claude/skills -name 'SKILL.md')
-[ $failed -eq 0 ] && echo "[PASS] SKILL.md 検証" || echo "[FAIL] SKILL.md 検証"
-```
+if [ $skill_failed -eq 0 ]; then
+  skill_result="[PASS] SKILL.md 検証"
+else
+  skill_result="[FAIL] SKILL.md 検証"
+  total_failed=$((total_failed + 1))
+fi
 
-### 4. symlink 整合性確認
-
-```bash
-failed=0
-paths=(
-  "nvim"
-  "wezterm"
-  "zsh/.zshrc"
-  "starship/starship.toml"
-  "claude/settings.json"
-  "claude/skills"
-  "claude/CLAUDE.md"
-  "claude/statusline-command.sh"
-)
-for path in "${paths[@]}"; do
+# 4. symlink 整合性確認
+symlink_failed=0
+for path in nvim wezterm zsh/.zshrc starship/starship.toml claude/settings.json claude/skills claude/CLAUDE.md claude/statusline-command.sh; do
   if [ ! -e "$path" ]; then
     echo "  ERROR: 存在しません: $path"
-    failed=1
+    symlink_failed=1
   fi
 done
-[ $failed -eq 0 ] && echo "[PASS] symlink 整合性" || echo "[FAIL] symlink 整合性"
+if [ $symlink_failed -eq 0 ]; then
+  symlink_result="[PASS] symlink 整合性"
+else
+  symlink_result="[FAIL] symlink 整合性"
+  total_failed=$((total_failed + 1))
+fi
+
+# サマリ表示
+echo "========================================"
+echo "  ローカルチェック結果"
+echo "========================================"
+echo "$shellcheck_result"
+echo "$luacheck_result"
+echo "$skill_result"
+echo "$symlink_result"
+echo "========================================"
+if [ $total_failed -eq 0 ]; then
+  echo "すべてのチェックが通過しました ✓"
+else
+  echo "${total_failed} 件のチェックが失敗しました"
+fi
 ```
-
-## 完了後
-
-全チェック結果を以下の形式でまとめて表示してください：
-
-```
-========================================
-  ローカルチェック結果
-========================================
-[PASS] ShellCheck
-[PASS] Luacheck
-[PASS] SKILL.md 検証
-[PASS] symlink 整合性
-========================================
-すべてのチェックが通過しました ✓
-```
-
-FAILがある場合は「X 件のチェックが失敗しました」と表示してください。

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: check
+description: CIと同等のローカルチェックを実行する。shellcheck・luacheck・SKILL.md検証・symlink整合性を確認する。ユーザーが「チェック」「CI確認」「ローカルで確認」などと言ったときに使う
+tools: [Bash]
+---
+
+以下の4つのチェックをすべて実行してください。1つが失敗しても残りを続行し、最後にサマリを表示してください。
+
+## チェック内容
+
+### 1. ShellCheck
+
+```bash
+if ! command -v shellcheck &>/dev/null; then
+  echo "[SKIP] shellcheck がインストールされていません"
+else
+  shellcheck setup.sh && echo "[PASS] ShellCheck" || echo "[FAIL] ShellCheck"
+fi
+```
+
+### 2. Luacheck
+
+```bash
+if ! command -v luacheck &>/dev/null; then
+  echo "[SKIP] luacheck がインストールされていません"
+else
+  luacheck nvim/lua/ && echo "[PASS] Luacheck" || echo "[FAIL] Luacheck"
+fi
+```
+
+### 3. SKILL.md フロントマター検証
+
+```bash
+failed=0
+while IFS= read -r file; do
+  if ! head -1 "$file" | grep -q '^---$'; then
+    echo "  ERROR: フロントマターがありません: $file"
+    failed=1
+    continue
+  fi
+  if ! awk '/^---$/{f++} f==1' "$file" | grep -q '^name:'; then
+    echo "  ERROR: name フィールドがありません: $file"
+    failed=1
+  fi
+  if ! awk '/^---$/{f++} f==1' "$file" | grep -q '^description:'; then
+    echo "  ERROR: description フィールドがありません: $file"
+    failed=1
+  fi
+done < <(find claude/skills -name 'SKILL.md')
+[ $failed -eq 0 ] && echo "[PASS] SKILL.md 検証" || echo "[FAIL] SKILL.md 検証"
+```
+
+### 4. symlink 整合性確認
+
+```bash
+failed=0
+paths=(
+  "nvim"
+  "wezterm"
+  "zsh/.zshrc"
+  "starship/starship.toml"
+  "claude/settings.json"
+  "claude/skills"
+  "claude/CLAUDE.md"
+  "claude/statusline-command.sh"
+)
+for path in "${paths[@]}"; do
+  if [ ! -e "$path" ]; then
+    echo "  ERROR: 存在しません: $path"
+    failed=1
+  fi
+done
+[ $failed -eq 0 ] && echo "[PASS] symlink 整合性" || echo "[FAIL] symlink 整合性"
+```
+
+## 完了後
+
+全チェック結果を以下の形式でまとめて表示してください：
+
+```
+========================================
+  ローカルチェック結果
+========================================
+[PASS] ShellCheck
+[PASS] Luacheck
+[PASS] SKILL.md 検証
+[PASS] symlink 整合性
+========================================
+すべてのチェックが通過しました ✓
+```
+
+FAILがある場合は「X 件のチェックが失敗しました」と表示してください。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.'
+          severity: warning
+
+  luacheck:
+    name: Luacheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install luacheck
+        run: |
+          sudo apt-get install -y luarocks
+          sudo luarocks install luacheck
+      - name: Run luacheck
+        run: luacheck nvim/lua/
+
+  skill-validation:
+    name: SKILL.md Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate SKILL.md frontmatter
+        run: |
+          failed=0
+          while IFS= read -r file; do
+            # フロントマターの開始確認
+            if ! head -1 "$file" | grep -q '^---$'; then
+              echo "ERROR: フロントマターがありません: $file"
+              failed=1
+              continue
+            fi
+            # name フィールドの確認
+            if ! awk '/^---$/{f++} f==1' "$file" | grep -q '^name:'; then
+              echo "ERROR: name フィールドがありません: $file"
+              failed=1
+            fi
+            # description フィールドの確認
+            if ! awk '/^---$/{f++} f==1' "$file" | grep -q '^description:'; then
+              echo "ERROR: description フィールドがありません: $file"
+              failed=1
+            fi
+          done < <(find claude/skills -name 'SKILL.md')
+          exit $failed
+
+  symlink-check:
+    name: Symlink Source Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check symlink source files exist
+        run: |
+          failed=0
+          paths=(
+            "nvim"
+            "wezterm"
+            "zsh/.zshrc"
+            "starship/starship.toml"
+            "claude/settings.json"
+            "claude/skills"
+            "claude/CLAUDE.md"
+            "claude/statusline-command.sh"
+          )
+          for path in "${paths[@]}"; do
+            if [ ! -e "$path" ]; then
+              echo "ERROR: 存在しません: $path"
+              failed=1
+            else
+              echo "OK: $path"
+            fi
+          done
+          exit $failed

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,2 @@
+globals = { "vim" }
+max_line_length = false

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,2 +1,2 @@
-globals = { "vim" }
+globals = { "vim", "_LAZYGIT_TOGGLE" }
 max_line_length = false

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 - **Neovim** - テキストエディタ（Lazy.nvim, LSP, Treesitter, Neo-tree 等）
 - **WezTerm** - ターミナルエミュレータ
 - **Zsh** - シェル設定（エイリアス、fzf 連携等）
+- **Starship** - プロンプト設定
 - **Claude Code** - AI コーディングアシスタント設定
 
 ## Neovim プラグイン一覧
@@ -41,6 +42,12 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 ```
 .
 ├── setup.sh              # セットアップスクリプト
+├── .luacheckrc           # Lua linter 設定
+├── .github/
+│   └── workflows/
+│       └── ci.yml        # GitHub Actions CI
+├── .claude/
+│   └── skills/           # プロジェクト固有スキル
 ├── nvim/
 │   ├── init.lua
 │   ├── lazy-lock.json
@@ -51,23 +58,7 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 │       ├── plugins/
 │       │   ├── init.lua
 │       │   ├── alpha.lua
-│       │   ├── barbar.lua
-│       │   ├── cmp.lua
-│       │   ├── colorscheme.lua
-│       │   ├── conform.lua
-│       │   ├── dap.lua
-│       │   ├── diffview.lua
-│       │   ├── lsp.lua
-│       │   ├── lualine.lua
-│       │   ├── markdown-preview.lua
-│       │   ├── neo-tree.lua
-│       │   ├── ruby.lua
-│       │   ├── snippets.lua
-│       │   ├── swenv.lua
-│       │   ├── tabset.lua
-│       │   ├── telescope.lua
-│       │   ├── toggleterm.lua
-│       │   ├── treesitter.lua
+│       │   ├── ...
 │       │   └── illuminate.lua
 │       └── ui/
 │           └── colorscheme.lua
@@ -78,12 +69,18 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 │   └── tabs.lua
 ├── zsh/
 │   └── .zshrc
-├── claude/
-│   ├── settings.json
-│   └── commands/
-│       ├── create-pr.md
-│       └── update-readme.md
-└── README.md
+├── starship/
+│   └── starship.toml
+└── claude/
+    ├── settings.json
+    ├── CLAUDE.md
+    ├── statusline-command.sh
+    └── skills/            # Claude Code カスタムスキル
+        ├── commit/
+        ├── pr/
+        ├── issue/
+        ├── release/
+        └── ...
 ```
 
 ## セットアップ
@@ -93,7 +90,7 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 [Homebrew](https://brew.sh/) を使用してインストールします。
 
 ```sh
-brew install neovim eza fzf
+brew install neovim eza fzf starship
 brew install --cask wezterm
 ```
 
@@ -117,18 +114,38 @@ cd ~/dev/dotfiles
 | `nvim/` | `~/.config/nvim` |
 | `wezterm/` | `~/.config/wezterm` |
 | `zsh/.zshrc` | `~/.zshrc` |
+| `starship/starship.toml` | `~/.config/starship.toml` |
 | `claude/settings.json` | `~/.claude/settings.json` |
-| `claude/commands` | `~/.claude/commands` |
+| `claude/skills` | `~/.claude/skills` |
+| `claude/CLAUDE.md` | `~/.claude/CLAUDE.md` |
+| `claude/statusline-command.sh` | `~/.claude/statusline-command.sh` |
 
 **機能:**
 - 既存のファイル/ディレクトリがある場合は `.backup.YYYYMMDD_HHMMSS` 形式で自動バックアップ
 - `~/.config` ディレクトリがなければ自動作成
 - bash / zsh どちらでも実行可能（POSIX 互換）
 
-## Claude Code カスタムコマンド
+## CI
 
-| コマンド | 説明 |
+GitHub Actions で以下のチェックを自動実行します（PR・main push 時）。
+
+| ジョブ | 内容 |
 |---|---|
+| ShellCheck | `setup.sh` の静的解析 |
+| Luacheck | `nvim/lua/` 配下の Lua ファイル解析 |
+| SKILL.md Validation | `claude/skills/**/SKILL.md` のフロントマター検証 |
+| Symlink Source Check | `setup.sh` が参照するファイル・ディレクトリの存在確認 |
+
+## Claude Code カスタムスキル
+
+| スキル | 説明 |
+|---|---|
+| `/commit` | 差分を解析して日本語コミットメッセージを生成・実行 |
 | `/pr [base-branch]` | PR を自動作成（タイトル・本文をコミットから自動生成） |
 | `/issue [topic]` | GitHub Issue を作成（ヒアリング形式） |
+| `/release` | リリース処理を自動化（ブランチ作成・マージ・タグ付与） |
+| `/f-create-pr` | Forgejo リポジトリに PR を自動作成 |
+| `/f-create-issue` | Forgejo リポジトリに Issue を作成 |
 | `/update-readme` | プロジェクトを調査して README を更新 |
+| `/setup-claude-md` | インタビュー形式で CLAUDE.md を対話的に作成 |
+| `/check` | CI と同等のローカルチェックを実行 |

--- a/setup.sh
+++ b/setup.sh
@@ -86,7 +86,7 @@ main() {
 
     # ~/.config ディレクトリを作成（なければ）
     if [ ! -d "$HOME/.config" ]; then
-        print_info "~/.config ディレクトリを作成"
+        print_info "$HOME/.config ディレクトリを作成"
         mkdir -p "$HOME/.config"
     fi
 


### PR DESCRIPTION
## 概要

- GitHub Actions CI ワークフローを新規追加（ShellCheck・Luacheck・SKILL.md検証・symlink整合性）
- `/check` スキルでCIと同等のチェックをローカルで実行できるように
- ShellCheck・Luacheck の警告を修正

## 背景・モチベーション

dotfilesリポジトリにCIが存在せず、シェルスクリプトやLuaファイルの品質チェックが手動だった。
PR・mainへのマージ時に自動チェックが走るようにし、ローカルでも同等のチェックを素早く実行できる環境を整備した。

## 変更の詳細

- `.github/workflows/ci.yml`: 4ジョブ並列実行（ShellCheck / Luacheck / SKILL.md frontmatter検証 / symlink整合性確認）、PR・main pushでトリガー
- `.luacheckrc`: luacheck設定追加（`vim`・`_LAZYGIT_TOGGLE` グローバルを許可）
- `.claude/skills/check/SKILL.md`: ローカルチェックスキルを追加（1回のBash呼び出しで全チェック完結）
- `setup.sh`: SC2088（クォート内チルダ）警告を修正
- `README.md`: Starship追加・構成ツリー更新・CIセクション追加・スキル一覧を全9スキルに更新

## 動作確認

- [x] `/check` スキルで全チェック PASS 確認
- [x] ShellCheck・Luacheck ともにエラー・警告ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)