### PR TITLE
ci: develop ブランチへの CI トリガーを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   shellcheck:


### PR DESCRIPTION
## 概要
- CI ワークフローのトリガーに `develop` ブランチを追加

## 背景・モチベーション
デフォルトブランチが `develop` であるため、`develop` への push および pull_request 時にも CI が動作する必要があった。

## 変更の詳細
- `.github/workflows/ci.yml` の `push.branches` と `pull_request.branches` に `develop` を追加

## 動作確認
- [ ] `develop` ブランチへの push 時に GitHub Actions が起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)