### PR TITLE
HOME を XDG Base Directory Specification 準拠に整理（#39）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# macOS
+.DS_Store

--- a/git/config
+++ b/git/config
@@ -1,0 +1,3 @@
+[user]
+	name = tofu-dev0123
+	email = m.komukai0123@gmail.com

--- a/setup.sh
+++ b/setup.sh
@@ -112,6 +112,9 @@ main() {
     # Starship
     create_symlink "$DOTFILES_DIR/starship/starship.toml" "$HOME/.config/starship.toml"
 
+    # Git
+    create_symlink "$DOTFILES_DIR/git/config" "$HOME/.config/git/config"
+
     # Claude Code
     create_symlink "$DOTFILES_DIR/claude/settings.json" "$HOME/.claude/settings.json"
     create_symlink "$DOTFILES_DIR/claude/skills" "$HOME/.claude/skills"

--- a/setup.sh
+++ b/setup.sh
@@ -101,7 +101,13 @@ main() {
     create_symlink "$DOTFILES_DIR/wezterm" "$HOME/.config/wezterm"
 
     # Zsh
-    create_symlink "$DOTFILES_DIR/zsh/.zshrc" "$HOME/.zshrc"
+    # .zshenv は zsh 仕様で $HOME 直下がハードコード
+    create_symlink "$DOTFILES_DIR/zsh/.zshenv" "$HOME/.zshenv"
+    # .zprofile / .zshrc は ZDOTDIR ($XDG_CONFIG_HOME/zsh) 配下から読まれる
+    create_symlink "$DOTFILES_DIR/zsh/.zprofile" "$HOME/.config/zsh/.zprofile"
+    create_symlink "$DOTFILES_DIR/zsh/.zshrc" "$HOME/.config/zsh/.zshrc"
+    # 履歴ファイルの親ディレクトリを事前作成
+    mkdir -p "$HOME/.local/state/zsh"
 
     # Starship
     create_symlink "$DOTFILES_DIR/starship/starship.toml" "$HOME/.config/starship.toml"

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -1,0 +1,8 @@
+# shellcheck shell=bash
+# .zprofile はログインシェルで .zshrc より前に読まれる
+# ZDOTDIR が設定されているため $ZDOTDIR/.zprofile から読まれる
+
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# shellcheck source=/dev/null
+. "$HOME/.cargo/env"

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -3,6 +3,3 @@
 # ZDOTDIR が設定されているため $ZDOTDIR/.zprofile から読まれる
 
 eval "$(/opt/homebrew/bin/brew shellenv)"
-
-# shellcheck source=/dev/null
-. "$HOME/.cargo/env"

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -10,3 +10,6 @@ export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
 
 # zsh 本体の設定ファイル探索先を XDG 配下に寄せる
 export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
+
+# less の履歴を保存しない（XDG 化のため $HOME 直下の .lesshst を発生させない）
+export LESSHISTFILE="-"

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -19,3 +19,8 @@ export LESSHISTFILE="-"
 export MYSQL_HISTFILE="$XDG_STATE_HOME/mysql/history"
 export SQLITE_HISTORY="$XDG_STATE_HOME/sqlite/history"
 export NODE_REPL_HISTORY="$XDG_STATE_HOME/node/repl_history"
+
+# 言語ランタイム/CLI のキャッシュ・設定を XDG 配下に
+export NPM_CONFIG_CACHE="$XDG_CACHE_HOME/npm"
+export GRADLE_USER_HOME="$XDG_DATA_HOME/gradle"
+export DOCKER_CONFIG="$XDG_CONFIG_HOME/docker"

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -13,3 +13,9 @@ export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 
 # less の履歴を保存しない（XDG 化のため $HOME 直下の .lesshst を発生させない）
 export LESSHISTFILE="-"
+
+# REPL/CLI 履歴を XDG_STATE_HOME 配下に予防的に振る
+# （ホストでこれらのツールを使う場面が出てきても $HOME 直下に履歴が生成されないようにする）
+export MYSQL_HISTFILE="$XDG_STATE_HOME/mysql/history"
+export SQLITE_HISTORY="$XDG_STATE_HOME/sqlite/history"
+export NODE_REPL_HISTORY="$XDG_STATE_HOME/node/repl_history"

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,0 +1,12 @@
+# shellcheck shell=bash
+# XDG Base Directory Specification
+# .zshenv は全ての zsh 起動で最初に読み込まれる唯一のファイル
+# XDG 変数と ZDOTDIR をここで定義することで、後続の .zshrc やサブシェル全体に伝搬する
+
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+# zsh 本体の設定ファイル探索先を XDG 配下に寄せる
+export ZDOTDIR="$XDG_CONFIG_HOME/zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,4 +1,7 @@
 # shellcheck shell=bash
+# 履歴は XDG_STATE_HOME 配下に分離（HISTFILE は対話シェル固有のため .zshrc に置く）
+export HISTFILE="$XDG_STATE_HOME/zsh/history"
+
 export PATH="$HOME/.rbenv/shims:$PATH"
 
 # >>> conda initialize >>>

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -16,8 +16,8 @@ cd() {
 	builtin cd "$@" && ls -l
 }
 
-# shellcheck source=/dev/null
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+# fzf シェル統合（キーバインド・補完を有効化）
+eval "$(fzf --zsh)"
 
 export PATH="$HOME/.npm-global/bin:$PATH"
 eval "$(rbenv init -)"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -4,21 +4,6 @@ export HISTFILE="$XDG_STATE_HOME/zsh/history"
 
 export PATH="$HOME/.rbenv/shims:$PATH"
 
-# >>> conda initialize >>>
-# !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/opt/anaconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "/opt/anaconda3/etc/profile.d/conda.sh" ]; then
-        . "/opt/anaconda3/etc/profile.d/conda.sh"
-    else
-        export PATH="/opt/anaconda3/bin:$PATH"
-    fi
-fi
-unset __conda_setup
-# <<< conda initialize <<<
-
 export PATH="$HOME/.local/bin:$PATH"
 
 alias ls="eza --icons --group-directories-first"


### PR DESCRIPTION
## 概要
- \$HOME 直下に散在していた dotfile を XDG Base Directory Specification に準拠して整理
- zsh / git / less / docker など対応可能なツールを XDG 配下に移行
- 不要キャッシュ・未使用設定を削除し、\$HOME 直下を 50+ 個から 22 個に削減（約 14GB 解放）
- Closes #39

## 背景・モチベーション
- \$HOME 直下に設定・データ・履歴・キャッシュが区別なく散在していた
- バックアップすべきものとそうでないものが混在し、運用上の不明瞭さがあった
- 将来的な Nix（home-manager）導入時の \`xdg.configFile\` 運用との整合性を取りやすくする

## 変更の詳細

### Phase 0: zsh 基盤の XDG 化
- \`zsh/.zshenv\` 新設: XDG 4 変数 + ZDOTDIR を定義
- \`.zshrc\` を ZDOTDIR (\$XDG_CONFIG_HOME/zsh) 配下から読まれるよう移動
- \`.zprofile\` を repo 管理化（Homebrew shellenv 起動の救出のため）
- HISTFILE を \$XDG_STATE_HOME/zsh/history へ

### Phase 1: ネイティブ XDG 対応ツール
- \`~/.gitconfig\` を repo 管理に移行（\`git/config\` → \`~/.config/git/config\`）
- \`LESSHISTFILE=-\` を .zshenv に追加（less 履歴を保存しない方針）

### Phase 2: REPL/CLI 履歴
- 未使用履歴ファイル（.viminfo / .python_history / .mysql_history / .sqlite_history）削除
- 予防的 env var 追加: MYSQL_HISTFILE / SQLITE_HISTORY / NODE_REPL_HISTORY

### Phase 3: 不使用ランタイム整理 + 現役ツール XDG 化
- conda init ブロック削除 + \`.anaconda\` / \`.conda\` / \`.continuum\` / \`.jupyter\` / \`.ipython\` 削除
- rust 削除（\`.cargo\` / \`.rustup\`、約 2.6GB）
- npm/gradle: キャッシュ削除 + NPM_CONFIG_CACHE / GRADLE_USER_HOME 設定
- docker: Desktop 残骸を整理し \`~/.config/docker/\` に必要分のみ移行（DOCKER_CONFIG 設定）

### Phase 4: \$HOME 直下のクリーンアップ
- 旧シェル系（.bashrc / .bash_profile / .profile / .fzf.bash）削除
- 古い未使用（.groovy / .hawtjni / .matplotlib / .ipynb_checkpoints / .virtual_documents / .claude.json.backup / .zsh_sessions）削除
- 未使用エディタ・ツール（.cursor / .devdb / .serena）削除
- .fzf.zsh を .zshrc に inline 化
- .gitignore 新設（.DS_Store 除外）

## 動作確認
- [ ] 新ターミナル起動で XDG 4 変数が期待値に展開
- [ ] starship プロンプト表示
- [ ] rbenv / gem / bundle が動作（既存挙動維持）
- [ ] 履歴引き継ぎ（Ctrl+R で過去コマンド検索可）
- [ ] git config user.name / user.email
- [ ] docker / docker compose / docker context

## 別 issue / 別タイミングに切り出した課題
- #47: 個人/会社など複数 git アカウントの切替設定
- #48: キャッシュ類の定期クリーンアップ運用
- #42 にコメント追加: rbenv / gem / bundle・aws の Nix 化時対応

## 注意事項・補足
- 残り 22 個の dotfile は (1) XDG 主ディレクトリ自体、(2) macOS / OpenSSH 仕様で固定、(3) ツール側が XDG 非対応、(4) Nix 化で対応予定、(5) root 所有テンプレート、のいずれかで意図的に残置
- \`.tcshrc\` / \`.xonshrc\` は root 所有のため sudo が必要、害なしのため放置
- conda 本体（\`/opt/anaconda3/\`）は本 issue のスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)