### PR TITLE
feat: home-manager 導入と starship を Nix 化（#42 Phase 0+1 PoC）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
           paths=(
             "nvim/.config/nvim"
             "wezterm/.config/wezterm"
-            "starship/.config/starship.toml"
             "zsh/.zshenv"
             "zsh/.config/zsh"
             "git/.config/git"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 # macOS
 .DS_Store
+
+# Nix
+result
+result-*
+
+# direnv (Phase 4 で導入予定だが先回り)
+.direnv/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 - **Starship** - プロンプト設定
 - **Claude Code** - AI コーディングアシスタント設定
 
+## セットアップ方式
+
+各ツールは以下のいずれかの方式で `$HOME` 配下に配置されます。
+home-manager (Nix) への移行を段階的に進めており、Issue [#42](https://github.com/tofu-dev0123/dotfiles/issues/42) 以降で順次切り替え中です。
+
+| ツール | 管理方式 |
+|---|---|
+| Starship | home-manager (`mkOutOfStoreSymlink`) |
+| Neovim / WezTerm / Zsh / Git / Claude Code | `setup.sh`（symlink） |
+
+新規マシン構築・既存マシンでも、後述の「セットアップ」では **両方の手順を直列に実行** します（二者択一ではありません）。
+
 ## Neovim プラグイン一覧
 
 | プラグイン | 説明 | 設定ファイル |
@@ -99,35 +111,66 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 
 ## セットアップ
 
-### 1. 必要なツールのインストール
+セットアップは **(A) home-manager** と **(B) `./setup.sh`** の 2 段階で行います。両方とも実行してください。
 
-[Homebrew](https://brew.sh/) を使用してインストールします。
+### 0. 共通: 必要なツールのインストールとリポジトリ取得
+
+[Homebrew](https://brew.sh/) を使用してインストールします（`starship` は home-manager 側で別途扱うため除外）。
 
 ```sh
-brew install neovim eza fzf starship
+brew install neovim eza fzf
 brew install --cask wezterm
 ```
 
-### 2. リポジトリのクローン
+リポジトリをクローン:
 
 ```sh
 git clone https://github.com/<your-username>/dotfiles.git ~/dev/dotfiles
+cd ~/dev/dotfiles
 ```
 
-### 3. セットアップスクリプトの実行
+### (A) home-manager セットアップ
+
+`starship` は home-manager 経由で配置されます。
+
+#### A-1. Nix のインストール
+
+[Determinate Systems Installer](https://determinate.systems/posts/determinate-nix-installer/) を推奨します。
 
 ```sh
-cd ~/dev/dotfiles
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+```
+
+#### A-2. 既存 symlink の退避（既存マシンの初回切替時のみ）
+
+旧 `setup.sh` で張られた symlink が残っていると home-manager が「foreign file」として失敗します。初回のみ手動で削除してください。
+
+```sh
+rm -f ~/.config/starship.toml
+```
+
+#### A-3. home-manager の実行
+
+```sh
+nix run home-manager/master -- switch --flake .#komusan
+```
+
+`~/.config/starship.toml` がリポジトリ実体への symlink として配置されます（`mkOutOfStoreSymlink` で生成）。
+
+### (B) `./setup.sh` 実行
+
+残りのツール（Neovim / WezTerm / Zsh / Git / Claude Code）の symlink を作成します。
+
+```sh
 ./setup.sh
 ```
 
-セットアップスクリプトは以下の symlink を作成します（リポジトリ内のパスがそのまま `$HOME` 配下のパスになる）：
+セットアップスクリプトは以下の symlink を作成します：
 
 | ソース | リンク先 |
 |---|---|
 | `nvim/.config/nvim` | `~/.config/nvim` |
 | `wezterm/.config/wezterm` | `~/.config/wezterm` |
-| `starship/.config/starship.toml` | `~/.config/starship.toml` |
 | `zsh/.zshenv` | `~/.zshenv` |
 | `zsh/.config/zsh` | `~/.config/zsh` |
 | `git/.config/git` | `~/.config/git` |
@@ -135,6 +178,8 @@ cd ~/dev/dotfiles
 | `claude/.claude/CLAUDE.md` | `~/.claude/CLAUDE.md` |
 | `claude/.claude/skills` | `~/.claude/skills` |
 | `claude/.claude/statusline-command.sh` | `~/.claude/statusline-command.sh` |
+
+> Starship (`~/.config/starship.toml`) は home-manager 経由で配置されます（上記 (A) を参照）。
 
 **サブコマンド:**
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,49 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777349711,
+        "narHash": "sha256-PGKgo2dO6fK603QGI+DWXdKmS09pbJjjTxwRHdhkGZA=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c1140540536d483e2730320100f6835d62c94fdf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "tofu-dev0123 dotfiles - home-manager configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, home-manager, ... }:
+    let
+      system = "aarch64-darwin";
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+    in {
+      homeConfigurations."komusan" = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        modules = [ ./home.nix ];
+      };
+    };
+}

--- a/home.nix
+++ b/home.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+let
+  dotfilesPath = "${config.home.homeDirectory}/dev/dotfiles";
+in {
+  home.username = "komusan";
+  home.homeDirectory = "/Users/komusan";
+  home.stateVersion = "25.05";
+
+  programs.home-manager.enable = true;
+  xdg.enable = true;
+
+  # Phase 1 PoC: starship を mkOutOfStoreSymlink でリポジトリ実体に symlink
+  xdg.configFile."starship.toml".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/starship/.config/starship.toml";
+}

--- a/setup.sh
+++ b/setup.sh
@@ -35,7 +35,6 @@ DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 LINKS="
 nvim/.config/nvim
 wezterm/.config/wezterm
-starship/.config/starship.toml
 zsh/.zshenv
 zsh/.config/zsh
 git/.config/git


### PR DESCRIPTION
## Summary

Issue #42 のうち **Phase 0（home-manager 骨格）** と **Phase 1 PoC（starship 取り込み）** を実装した。
今後の段階移行（残りツール / packages / programs.* / runtime 化）は別 issue（#51 / #52 / #53 / #54）で対応する。

## 主な変更

- `flake.nix` / `home.nix` を新規作成し home-manager standalone 構成を確立（aarch64-darwin、`stateVersion = "25.05"`）
- starship 設定を `mkOutOfStoreSymlink` 経由でリポジトリ実体に symlink（編集→即反映を維持）
- `setup.sh` の `LINKS` および `.github/workflows/ci.yml` の `symlink-check` から starship 行を削除
- `README.md` に「セットアップ方式」セクションを新設し、`(A) home-manager` と `(B) ./setup.sh` の **2 段直列実行** を明記
- `.gitignore` に Nix (`result` / `result-*`) と direnv (`.direnv/`) を追加

## Test plan

- [x] `nix flake check` がエラーなく通る
- [x] `nix run home-manager/master -- switch --flake .#komusan` が成功する
- [x] `readlink -f ~/.config/starship.toml` がリポジトリ実体（`/Users/komusan/dev/dotfiles/starship/.config/starship.toml`）を指す（mkOutOfStoreSymlink 動作確認）
- [x] シェル再起動で starship プロンプトが正常表示
- [x] `./setup.sh --dry-run` の出力に starship が含まれない
- [x] `shellcheck setup.sh` で警告なし

## 関連 issue

- Closes #42
- 後続: #51（Phase 1 完了）, #52（Phase 2）, #53（Phase 3）, #54（Phase 4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)