### PR TITLE
全 dotfiles を home-manager の mkOutOfStoreSymlink で管理 (#51 Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
             "zsh/.zshenv"
             "zsh/.config/zsh"
             "git/.config/git"
+            "starship/.config/starship.toml"
             "claude/.claude/settings.json"
             "claude/.claude/skills"
             "claude/.claude/CLAUDE.md"

--- a/README.md
+++ b/README.md
@@ -12,15 +12,14 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 
 ## セットアップ方式
 
-各ツールは以下のいずれかの方式で `$HOME` 配下に配置されます。
-home-manager (Nix) への移行を段階的に進めており、Issue [#42](https://github.com/tofu-dev0123/dotfiles/issues/42) 以降で順次切り替え中です。
+全 dotfiles は home-manager (Nix) の `mkOutOfStoreSymlink` で `$HOME` 配下に配置されます。
+home-manager (Nix) への移行は段階的に進行中で、Phase 1 ([#51](https://github.com/tofu-dev0123/dotfiles/issues/51)) で全 dotfiles の symlink 化が完了しました。
 
 | ツール | 管理方式 |
 |---|---|
-| Starship | home-manager (`mkOutOfStoreSymlink`) |
-| Neovim / WezTerm / Zsh / Git / Claude Code | `setup.sh`（symlink） |
+| Starship / Neovim / WezTerm / Zsh / Git / Claude Code | home-manager (`mkOutOfStoreSymlink`) |
 
-新規マシン構築・既存マシンでも、後述の「セットアップ」では **両方の手順を直列に実行** します（二者択一ではありません）。
+`setup.sh` は zsh の state ディレクトリ事前作成のみを担当する補助スクリプトとして残っており、Phase 4 ([#54](https://github.com/tofu-dev0123/dotfiles/issues/54)) で廃止予定です。
 
 ## Neovim プラグイン一覧
 
@@ -56,7 +55,12 @@ home-manager (Nix) への移行を段階的に進めており、Issue [#42](http
 
 ```
 .
-├── setup.sh              # セットアップスクリプト
+├── flake.nix             # home-manager の flake 入口
+├── flake.lock            # flake 依存ロック
+├── home.nix              # home-manager 設定本体
+├── modules/
+│   └── dotfiles.nix      # 全 dotfiles の symlink 定義（mkOutOfStoreSymlink）
+├── setup.sh              # 補助スクリプト（zsh state ディレクトリ作成）
 ├── .luacheckrc           # Lua linter 設定
 ├── .github/
 │   └── workflows/
@@ -106,12 +110,12 @@ home-manager (Nix) への移行を段階的に進めており、Issue [#42](http
 ### ミラー型構造の利点
 
 - ディレクトリ構造が配置先を表現する（マッピング情報をスクリプトから排除）
-- 将来 [home-manager](https://nix-community.github.io/home-manager/) に移行する際、`xdg.configFile.<name>.source = ./<pkg>/.config/<name>` のように直接参照できる
+- [home-manager](https://nix-community.github.io/home-manager/) で `xdg.configFile.<name>.source = ./<pkg>/.config/<name>` のように直接参照できる
 - GNU Stow でも `stow nvim zsh git` だけで動作する構造
 
 ## セットアップ
 
-セットアップは **(A) home-manager** と **(B) `./setup.sh`** の 2 段階で行います。両方とも実行してください。
+全 dotfiles は home-manager 経由で配置されます。
 
 ### 0. 共通: 必要なツールのインストールとリポジトリ取得
 
@@ -129,11 +133,7 @@ git clone https://github.com/<your-username>/dotfiles.git ~/dev/dotfiles
 cd ~/dev/dotfiles
 ```
 
-### (A) home-manager セットアップ
-
-`starship` は home-manager 経由で配置されます。
-
-#### A-1. Nix のインストール
+### 1. Nix のインストール
 
 [Determinate Systems Installer](https://determinate.systems/posts/determinate-nix-installer/) を推奨します。
 
@@ -141,59 +141,47 @@ cd ~/dev/dotfiles
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 ```
 
-#### A-2. 既存 symlink の退避（既存マシンの初回切替時のみ）
+### 2. 既存 symlink の退避（既存マシンの初回切替時のみ）
 
-旧 `setup.sh` で張られた symlink が残っていると home-manager が「foreign file」として失敗します。初回のみ手動で削除してください。
+旧 `setup.sh` で張られた symlink が残っていると home-manager が「foreign file」として失敗します。
+**初回のみ手動で削除する**か、後述の `-b backup` オプションで退避してください。
+
+手動削除する場合:
 
 ```sh
 rm -f ~/.config/starship.toml
+rm -rf ~/.config/nvim ~/.config/wezterm ~/.config/zsh ~/.config/git
+rm -f ~/.zshenv
+rm -f ~/.claude/settings.json ~/.claude/CLAUDE.md ~/.claude/statusline-command.sh
+rm -rf ~/.claude/skills
 ```
 
-#### A-3. home-manager の実行
+> 上記はすべてリポジトリ実体への symlink なので削除しても dotfiles 本体には影響しません。
 
-```sh
-nix run home-manager/master -- switch --flake .#komusan
-```
+### 3. setup.sh で state ディレクトリを準備
 
-`~/.config/starship.toml` がリポジトリ実体への symlink として配置されます（`mkOutOfStoreSymlink` で生成）。
-
-### (B) `./setup.sh` 実行
-
-残りのツール（Neovim / WezTerm / Zsh / Git / Claude Code）の symlink を作成します。
+zsh の `HISTFILE` 配置先を作成します（home-manager の対象外）。
 
 ```sh
 ./setup.sh
 ```
 
-セットアップスクリプトは以下の symlink を作成します：
-
-| ソース | リンク先 |
-|---|---|
-| `nvim/.config/nvim` | `~/.config/nvim` |
-| `wezterm/.config/wezterm` | `~/.config/wezterm` |
-| `zsh/.zshenv` | `~/.zshenv` |
-| `zsh/.config/zsh` | `~/.config/zsh` |
-| `git/.config/git` | `~/.config/git` |
-| `claude/.claude/settings.json` | `~/.claude/settings.json` |
-| `claude/.claude/CLAUDE.md` | `~/.claude/CLAUDE.md` |
-| `claude/.claude/skills` | `~/.claude/skills` |
-| `claude/.claude/statusline-command.sh` | `~/.claude/statusline-command.sh` |
-
-> Starship (`~/.config/starship.toml`) は home-manager 経由で配置されます（上記 (A) を参照）。
-
-**サブコマンド:**
+### 4. home-manager の実行
 
 ```sh
-./setup.sh                 # symlink を作成する
-./setup.sh --dry-run       # 実行せずに何をするか表示する
-./setup.sh --clean-backups # 既存の .backup.* を列挙して削除する
+nix run home-manager/master -- switch --flake .#komusan -b backup
 ```
 
-**機能:**
-- 既存 symlink は上書き（idempotent）
-- 既存の**実体ファイル**がある場合は安全のためエラーで停止（手動で退避してから再実行）
-- 親ディレクトリと `~/.local/state/zsh` を自動作成
-- bash / zsh / sh どちらでも実行可能（POSIX 互換）
+`-b backup` を付けると衝突したファイルを `<path>.backup` に退避してくれます。
+退避された `.backup` ファイルは確認後に `./setup.sh --clean-backups` で削除可能です。
+
+### 5. 通常運用
+
+設定変更後は以下で適用します（`-b backup` は初回のみ必要）。
+
+```sh
+home-manager switch --flake .#komusan
+```
 
 ## CI
 

--- a/home.nix
+++ b/home.nix
@@ -1,15 +1,11 @@
 { config, pkgs, ... }:
-let
-  dotfilesPath = "${config.home.homeDirectory}/dev/dotfiles";
-in {
+{
+  imports = [ ./modules/dotfiles.nix ];
+
   home.username = "komusan";
   home.homeDirectory = "/Users/komusan";
   home.stateVersion = "25.05";
 
   programs.home-manager.enable = true;
   xdg.enable = true;
-
-  # Phase 1 PoC: starship を mkOutOfStoreSymlink でリポジトリ実体に symlink
-  xdg.configFile."starship.toml".source =
-    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/starship/.config/starship.toml";
 }

--- a/modules/dotfiles.nix
+++ b/modules/dotfiles.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+let
+  dotfilesPath = "${config.home.homeDirectory}/dev/dotfiles";
+  link = path: config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/${path}";
+in {
+  xdg.configFile = {
+    "nvim".source         = link "nvim/.config/nvim";
+    "wezterm".source      = link "wezterm/.config/wezterm";
+    "zsh".source          = link "zsh/.config/zsh";
+    "git".source          = link "git/.config/git";
+    "starship.toml".source = link "starship/.config/starship.toml";
+  };
+
+  home.file = {
+    ".zshenv".source                       = link "zsh/.zshenv";
+    ".claude/settings.json".source         = link "claude/.claude/settings.json";
+    ".claude/CLAUDE.md".source             = link "claude/.claude/CLAUDE.md";
+    ".claude/skills".source                = link "claude/.claude/skills";
+    ".claude/statusline-command.sh".source = link "claude/.claude/statusline-command.sh";
+  };
+}

--- a/setup.sh
+++ b/setup.sh
@@ -28,21 +28,10 @@ DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # symlink 対象のリスト（リポジトリからの相対パス）
 # 形式: <package>/<HOME相対パス>
-# 例: nvim/.config/nvim → $DOTFILES_DIR/nvim/.config/nvim を $HOME/.config/nvim に symlink
 #
-# claude/ 配下は ~/.claude/ に Claude Code 自身がステートを書き込むため、
-# .claude/ 全体ではなく管理対象ファイル/ディレクトリ単位で symlink する。
-LINKS="
-nvim/.config/nvim
-wezterm/.config/wezterm
-zsh/.zshenv
-zsh/.config/zsh
-git/.config/git
-claude/.claude/settings.json
-claude/.claude/CLAUDE.md
-claude/.claude/skills
-claude/.claude/statusline-command.sh
-"
+# Phase 1 (#51) で全 dotfiles を home-manager の mkOutOfStoreSymlink へ移行したため空。
+# Phase 4 (#54) でこの setup.sh 自体を廃止する予定。
+LINKS=""
 
 # 事前作成するディレクトリ（ツールが書き込むパス）
 PRE_MKDIRS="


### PR DESCRIPTION
## 概要
- Phase 0+1 PoC ([#42](https://github.com/tofu-dev0123/dotfiles/issues/42)) で確立した `mkOutOfStoreSymlink` パターンを残り全 dotfiles へ展開
- starship を含む全 9 ファイル/ディレクトリを `modules/dotfiles.nix` に集約
- `setup.sh` の symlink 作成責務を home-manager に移譲

Closes #51

## 背景・モチベーション
[#42](https://github.com/tofu-dev0123/dotfiles/issues/42) で starship を PoC として `mkOutOfStoreSymlink` 方式に移行済み。
本 PR ([#51](https://github.com/tofu-dev0123/dotfiles/issues/51)) では残りの全 dotfiles（claude / git / nvim / wezterm / zsh）を同じ方式で機械的に移行し、`setup.sh` が張っていた symlink と等価な状態を home-manager 側に再現する。
これにより symlink 管理が二重化されている状態を解消し、Phase 2 以降のパッケージ管理 Nix 化への土台を整える。

## 変更の詳細
- `modules/dotfiles.nix` を新規作成し、全 dotfiles の symlink 定義を集約
  - `xdg.configFile`: nvim / wezterm / zsh / git / starship.toml
  - `home.file`: .zshenv / .claude/{settings.json, CLAUDE.md, skills, statusline-command.sh}
- `home.nix` から starship の直書き定義を削除し、`imports = [ ./modules/dotfiles.nix ]` で読み込む形に変更
- `setup.sh` の `LINKS` 配列を空に縮退（`PRE_MKDIRS` の zsh state ディレクトリ作成は維持）
  - Phase 4 ([#54](https://github.com/tofu-dev0123/dotfiles/issues/54)) で setup.sh ごと廃止予定
- `README.md` のセットアップ手順を更新
  - 旧 `setup.sh` symlink の退避手順を明示
  - `home-manager switch -b backup` で初回衝突を退避する手順を追加
  - 通常運用も `home-manager switch` に統一
- `.github/workflows/ci.yml` の Symlink Source Check に `starship/.config/starship.toml` を追加

## 動作確認
- [x] `nix flake check` が成功
- [x] `nix build .#homeConfigurations.komusan.activationPackage` でビルド成功
- [x] `home-manager switch -b backup` 実行後、全 10 個の symlink が `mkOutOfStoreSymlink` 経由でリポジトリ実体を指すことを確認
- [x] `realpath` で各 symlink の最終解決先がリポジトリ実体になることを確認
- [x] `shellcheck setup.sh` がパス
- [ ] シェル再起動して既存と同じ環境が動くことを確認（マージ後にユーザー側で実施）

## 注意事項・補足
- 既存マシンでこのブランチを取り込む際は、README の手順 2（既存 symlink の退避）を必ず実施してください。
- Phase 3 ([#53](https://github.com/tofu-dev0123/dotfiles/issues/53)) で `programs.zsh` を導入する際に、`PRE_MKDIRS` の `.local/state/zsh` 事前作成を home-manager 側へ吸収させる予定です（同 issue にコメント済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)