### PR TITLE
fix: zsh 起動時の rbenv エラー解消と nh 導入

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -23,6 +23,7 @@
     jq
     lazygit
     lua54Packages.luacheck
+    nh
     railway
     shellcheck
     stylua

--- a/modules/shell-env.nix
+++ b/modules/shell-env.nix
@@ -7,6 +7,9 @@
 # 対話シェルでのみ有効。非対話シェルでの伝搬問題は #59 で別途対応する想定。
 {
   home.sessionVariables = {
+    # nh のデフォルト flake パス（nh home switch だけで切り替え可能に）
+    NH_FLAKE = "${config.home.homeDirectory}/dev/dotfiles";
+
     # less の履歴を保存しない
     LESSHISTFILE = "-";
 

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -19,7 +19,7 @@
       dcd = ''cd "$(find ~ -type d | fzf)"'';
     };
 
-    # cd 関数 / rbenv init 等、Nix 式に分解しづらいシェル処理
+    # cd 関数等、Nix 式に分解しづらいシェル処理
     initContent = builtins.readFile ../zsh/zshrc-extra.sh;
 
     # ログインシェルでのみ実行する Homebrew 環境設定
@@ -29,9 +29,8 @@
   };
 
   # PATH への追加
-  # rbenv shims, ユーザーローカル bin, npm-global bin
+  # ユーザーローカル bin, npm-global bin
   home.sessionPath = [
-    "${config.home.homeDirectory}/.rbenv/shims"
     "${config.home.homeDirectory}/.local/bin"
     "${config.home.homeDirectory}/.npm-global/bin"
   ];

--- a/zsh/zshrc-extra.sh
+++ b/zsh/zshrc-extra.sh
@@ -9,5 +9,3 @@
 cd() {
 	builtin cd "$@" && eza -l --icons --group-directories-first
 }
-
-eval "$(rbenv init -)"


### PR DESCRIPTION
## 概要
- 新規ターミナル起動時に `rbenv` コマンドが見つからずエラーになる問題を解消
- `nh` を導入し `home-manager switch --flake .#komusan` を `nh home switch` に簡略化

## 背景・モチベーション
- dotfiles のランタイム管理方針（言語ランタイムは flake + direnv 側に寄せる）に反して `rbenv init` の eval が `zshrc-extra.sh` に残っており、`~/.rbenv` 不在の環境でエラーが出ていた
- `home-manager switch --flake .#komusan` は毎回打つには長く、適用前に差分を確認したいケースも多いため、Nix helper (`nh`) を採用

## 変更の詳細
- `zsh/zshrc-extra.sh` から `eval "$(rbenv init -)"` を削除
- `modules/zsh.nix` の `home.sessionPath` から `~/.rbenv/shims` を削除し、関連コメントを更新
- `home.nix` の `home.packages` に `nh` を追加
- `modules/shell-env.nix` に `NH_FLAKE = ~/dev/dotfiles` を追加（`nh home switch` 単体で切り替え可能に）

## 動作確認
- [ ] 新規ターミナルを開いて `command not found: rbenv` が出ないこと
- [ ] `nh home switch` で home-manager 構成が切り替えられること
- [ ] `nh home switch -- --diff` で差分プレビューが表示されること

## 注意事項・補足
- 本 PR 適用後の初回のみ、従来の `home-manager switch --flake .#komusan` を実行して `nh` をインストールする必要あり
- 既存シェルでは `NH_FLAKE` が読み込まれていないため、`exec zsh -l` か新規タブで再ログインしてから `nh home switch` を実行する

🤖 Generated with [Claude Code](https://claude.com/claude-code)