### PR TITLE
fix: home-manager 設定を複数ユーザーで使えるよう汎用化

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,20 @@
         inherit system;
         config.allowUnfree = true;
       };
-    in {
-      homeConfigurations."komusan" = home-manager.lib.homeManagerConfiguration {
+      mkHome = username: home-manager.lib.homeManagerConfiguration {
         inherit pkgs;
-        modules = [ ./home.nix ];
+        modules = [
+          ./home.nix
+          {
+            home.username = username;
+            home.homeDirectory = "/Users/${username}";
+          }
+        ];
+      };
+    in {
+      homeConfigurations = {
+        komusan = mkHome "komusan";
+        masatokomukai = mkHome "masatokomukai";
       };
     };
 }

--- a/home.nix
+++ b/home.nix
@@ -9,8 +9,7 @@
     ./modules/direnv.nix
   ];
 
-  home.username = "komusan";
-  home.homeDirectory = "/Users/komusan";
+  # home.username / home.homeDirectory は flake.nix の mkHome から注入される
   home.stateVersion = "25.05";
 
   # programs.* で管理されないツールのみ home.packages で宣言


### PR DESCRIPTION
## 概要
- `flake.nix` の `homeConfigurations` を関数化し、複数ユーザーの設定を生成可能にする
- `home.nix` からハードコードされた `home.username` / `home.homeDirectory` を排除

## 背景・モチベーション
これまで `home.nix` に `komusan` 固有のユーザー名 / ホームディレクトリが直接書かれていたため、別ユーザー（例: `masatokomukai`）で home-manager を適用しようとすると home.nix を書き換える必要があった。複数 macOS 環境間で同じ dotfiles を共有しやすくするため、ユーザー単位の設定差分を flake 側で吸収できる構造に変更する。

## 変更の詳細
- `flake.nix`
  - `mkHome = username: ...` を追加し、与えられた username に応じて `home.username` / `home.homeDirectory` を注入するモジュールを生成
  - `homeConfigurations` に `komusan` と `masatokomukai` の 2 ユーザーを登録
- `home.nix`
  - `home.username` / `home.homeDirectory` の直書きを削除し、注入される旨のコメントに置き換え

## 動作確認
- [ ] `home-manager switch --flake .#komusan` が従来通り適用できる
- [ ] `home-manager switch --flake .#masatokomukai` が新規ユーザーで適用できる
- [ ] `nix flake check` がエラーなく通る

## 注意事項・補足
ユーザーを追加したい場合は `flake.nix` の `homeConfigurations` に `<username> = mkHome "<username>";` を追加するだけで対応できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)