### PR TITLE
feat: 個人/会社の複数 Git アカウント切替と共通 git config の整備 (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,56 @@ find ~ -maxdepth 4 -name '*.backup.*' -exec rm -rf {} +
 home-manager switch --flake .#komusan
 ```
 
+## 複数 Git アカウントの切替
+
+個人と会社のアカウントを使い分けるため、リポジトリの配置先に応じて `user.name` / `user.email` / SSH 鍵が自動切替されます（[#47](https://github.com/tofu-dev0123/dotfiles/issues/47)）。
+
+### ディレクトリ規約
+
+```
+~/work/                  # 会社アカウントの集約ルート
+├── mk-dt/               # 株式会社 MK-DT 用リポジトリ
+└── <将来の会社>/         # 会社追加時はここに掘る
+```
+
+- `~/work/<会社名>/` 配下のリポジトリ → 会社用 config を `includeIf` で読み込む
+- それ以外（`~/dev/` 等） → 個人用 config（`modules/git.nix` の `settings.user`）がそのまま適用
+
+`includeIf` ルールは `modules/git.nix` で宣言。include 先ファイルの**中身**は個人情報を含むためリポジトリ非管理で、各マシンに手動配置します。
+
+### ローカルで用意するファイル
+
+#### `~/.config/git/config.mk-dt`（必須）
+
+```ini
+[user]
+  name = <会社用 GitHub アカウント名>
+  email = <会社メールアドレス>
+
+[core]
+  sshCommand = "ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes"
+```
+
+- `~/work/mk-dt/` 配下で自動読込される
+- `core.sshCommand` で会社用 SSH 鍵を強制使用（個人鍵が誤って使われる事故を防ぐ）
+
+#### `~/.config/git/config.work-common`（任意）
+
+複数会社で共通させたい設定があれば記述。不要なら作成しなくてよい（git は存在しない include 先を黙殺する）。
+
+### SSH 鍵の前提
+
+- 会社用鍵: `~/.ssh/id_ed25519`
+- 個人用鍵: `~/.ssh/id_rsa`
+- `~/.ssh/config` ではホストエイリアス（`github.com-work` 等）を使わず、素の `git@github.com:...` URL で運用。鍵の選択はディレクトリ位置に応じて `core.sshCommand` が決定する
+
+### 動作確認
+
+```sh
+cd ~/work/mk-dt/<repo> && git config user.email   # 会社メールが返る
+cd ~/dev/<repo>        && git config user.email   # 個人メールが返る
+```
+
 ## プロジェクト単位のランタイム管理
 
 言語ランタイム（ruby / node / python 等）は dotfiles では扱わず、**プロジェクトごとに `flake.nix` + `.envrc` を配置**して direnv で自動切替します。テンプレートは [`docs/flake-template.md`](./docs/flake-template.md) を参照してください。

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -5,9 +5,37 @@
   programs.git = {
     enable = true;
 
-    settings.user = {
-      name = "tofu-dev0123";
-      email = "m.komukai0123@gmail.com";
+    settings = {
+      user = {
+        name = "tofu-dev0123";
+        email = "m.komukai0123@gmail.com";
+      };
+
+      # 安全・事故防止系
+      init.defaultBranch = "main";   # git init の初期ブランチを main に
+      fetch.prune = true;            # fetch でリモート消滅ブランチの追跡参照を自動掃除
+      push.default = "simple";       # push の挙動を明示（モダン Git のデフォルト）
+      push.autoSetupRemote = true;   # 新規ブランチ初回 push で -u 不要
+      rebase.autoStash = true;       # rebase 開始時に未コミット変更を自動 stash・終了時に復元
+
+      # 表示系
+      branch.sort = "-committerdate";       # git branch を最新更新順で表示
+      tag.sort = "version:refname";         # git tag を semver 順で表示
+      column.ui = "auto";                   # branch/tag を端末幅に応じてカラム表示
+      diff.algorithm = "histogram";         # diff の質を上げる
+      merge.conflictStyle = "zdiff3";       # コンフリクトマーカーに共通祖先も表示
+
+      # alias
+      alias = {
+        co = "checkout";
+        br = "branch";
+        ci = "commit";
+        st = "status -sb";
+        lg = "log --oneline --graph --decorate --all";
+        last = "log -1 HEAD";
+        unstage = "reset HEAD --";
+        uncommit = "reset --soft HEAD~1";
+      };
     };
 
     # 会社/個人アカウントの自動切替

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -10,6 +10,15 @@
       email = "m.komukai0123@gmail.com";
     };
 
+    # 会社/個人アカウントの自動切替
+    # ~/work/<会社名>/ 配下では会社用 config (user.name / user.email / core.sshCommand) を読み込む
+    # include 先のファイルは個人情報を含むため非管理（ローカルに手動配置）
+    # 詳細は README.md「複数 Git アカウントの切替」を参照
+    includes = [
+      { condition = "gitdir:~/work/";       path = "~/.config/git/config.work-common"; }
+      { condition = "gitdir:~/work/mk-dt/"; path = "~/.config/git/config.mk-dt"; }
+    ];
+
     ignores = [
       "**/.claude/settings.local.json"
     ];

--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -28,6 +28,14 @@
         show_milliseconds = false;
       };
       command_timeout = 1200;
+      custom.git_user = {
+        description = "現在の git リポジトリの user.name を表示する";
+        command = "git config user.name";
+        when = "git rev-parse --is-inside-work-tree 2>/dev/null";
+        format = "[ $symbol $output ]($style)";
+        symbol = "";
+        style = "fg:surface0 bg:sky";
+      };
       conda = {
         format = "[[ $symbol $environment ](fg:yellow bg:blue)($version) ]($style)";
         ignore_base = false;
@@ -65,7 +73,7 @@
       fill = {
         symbol = " ";
       };
-      format = "[](fg:yellow)$os[](fg:yellow bg:green)$directory[](fg:green bg:sky)$git_branch$git_status[](fg:sky bg:sapphire)$c$dart$gcloud$golang$gradle$java$kotlin$lua$nodejs$php$python$typst$ruby$rust[](fg:sapphire bg:blue)$conda$docker_context$package$aws[](fg:blue bg:surface0)$cmd_duration[](fg:surface0)$line_break$username$character";
+      format = "[](fg:yellow)$os[](fg:yellow bg:green)$directory[](fg:green bg:sky)\${custom.git_user}$git_branch$git_status[](fg:sky bg:sapphire)$c$dart$gcloud$golang$gradle$java$kotlin$lua$nodejs$php$python$typst$ruby$rust[](fg:sapphire bg:blue)$conda$docker_context$package$aws[](fg:blue bg:surface0)$cmd_duration[](fg:surface0)$line_break$username$character";
       gcloud = {
         disabled = true;
       };

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -6,6 +6,9 @@
   programs.zsh = {
     enable = true;
 
+    # fish 風のインライン補完候補（ghost text）。→ で確定
+    autosuggestion.enable = true;
+
     # ZDOTDIR を XDG 配下に明示固定（25.05 のデフォルト変更警告への対応）
     dotDir = "${config.xdg.configHome}/zsh";
 


### PR DESCRIPTION
## 概要
- ディレクトリ位置に応じて Git アカウント（user.name / email / SSH 鍵）を自動切替
- starship プロンプトに現在の git user.name を表示
- 共通 git config 項目（事故防止・表示系・alias）と zsh-autosuggestions を整備

## 背景・モチベーション
個人と会社のリポジトリを 1 マシンで扱う際に、`user.name` / `user.email` / SSH 鍵を意識せず使い分けたかった ([#47](https://github.com/tofu-dev0123/dotfiles/issues/47))。SSH 設定はホストエイリアス運用 (`github.com-work`) になっていたが徹底できておらず、リポジトリごとに origin URL が混在していた。`core.sshCommand` でディレクトリ駆動の鍵切替に統一して、誤鍵使用と誤コミット事故を構造的に防ぐ。あわせて、Issue 内の追加スコープにあった「共通 git config 項目の整備」も対象にした。

## 変更の詳細
### Git アカウント自動切替（modules/git.nix）
- `programs.git.includes` に以下のルールを追加:
  - `gitdir:~/work/` → `~/.config/git/config.work-common`（共通設定の placeholder）
  - `gitdir:~/work/mk-dt/` → `~/.config/git/config.mk-dt`（会社用 ID + sshCommand）
- include 先のファイル本体は個人情報を含むためリポジトリ非管理。ローカルでの作成手順は README に記載

### Starship プロンプト（modules/starship.nix）
- `custom.git_user` モジュールで現在の `git config user.name` を表示
- `git rev-parse --is-inside-work-tree` で git リポジトリ内のみ表示
- format 文字列の `$directory` と `$git_branch` の間に挿入

### 共通 git config 項目（modules/git.nix）
- 事故防止系: `init.defaultBranch=main` / `fetch.prune=true` / `push.default=simple` / `push.autoSetupRemote=true` / `rebase.autoStash=true`
- 表示系: `branch.sort=-committerdate` / `tag.sort=version:refname` / `column.ui=auto` / `diff.algorithm=histogram` / `merge.conflictStyle=zdiff3`
- alias: `co` / `br` / `ci` / `st` / `lg` / `last` / `unstage` / `uncommit`

### zsh-autosuggestions（modules/zsh.nix）
- `programs.zsh.autosuggestion.enable = true` で fish 風のインライン補完候補を有効化
- ローカルで実施した移行作業（コミット対象外）:
  - `~/d-make/` → `~/work/mk-dt/` に移動
  - `~/.ssh/config` のホストエイリアス（`github.com-work` / `github.com-personal`）を削除し、`Host github.com` で個人鍵をデフォルト化
  - `mcframe-front-frontend` の origin URL を `git@github.com-work:` → `git@github.com:` に修正
  - `~/.config/git/config.mk-dt` を新規作成

## 動作確認
- [x] `home-manager switch --flake .#komusan` が成功
- [x] `~/work/mk-dt/CBP/CBP_Frontend` で `git config user.email` → `m_komukai@mk-dt.com`
- [x] `~/work/mk-dt/CBP/CBP_Frontend` で `git config core.sshCommand` → `ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes`
- [x] `~/dev/dotfiles` で `git config user.email` → `m.komukai0123@gmail.com`
- [x] starship プロンプトで会社/個人で異なるアカウント名が表示されることを確認
- [x] `git config --global --get-regexp '^alias\.'` で 8 個の alias が登録
- [x] zsh-autosuggestions が `.zshrc` に source 済み

## 注意事項・補足
- `~/.config/git/config.mk-dt` 等の include 先ファイルはローカルでのみ存在。新マシン構築時は README の「複数 Git アカウントの切替」セクションに従って手動配置が必要
- カテゴリ D（`core.editor` / `commit.gpgsign`）は今回スコープ外
- closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)