### PR TITLE
serie を追加して git コミットツリーを TUI で閲覧可能に

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ home-manager (Nix) への移行は段階的に進行中で、Phase 1 ([#51](http
 | Zsh / Git / Starship / direnv | home-manager (`programs.*`) |
 | Neovim / WezTerm / Claude Code | home-manager (`mkOutOfStoreSymlink`) |
 | fzf | home-manager (`programs.fzf`)（zsh 統合自動有効化） |
-| cosign / cowsay / eza / gh / jq / lazygit / luacheck / railway / shellcheck / stylua | home-manager (`home.packages`) |
+| cosign / cowsay / eza / gh / jq / lazygit / luacheck / railway / serie / shellcheck / stylua | home-manager (`home.packages`) |
 | GUI / Cask アプリ (1Password / WezTerm 等) | Homebrew (`Brewfile`) |
 | プロジェクト固有のランタイム (ruby / node 等) | プロジェクト側 `flake.nix` + direnv（dotfiles では扱わない） |
 

--- a/home.nix
+++ b/home.nix
@@ -24,6 +24,7 @@
     lua54Packages.luacheck
     nh
     railway
+    serie
     shellcheck
     stylua
   ];


### PR DESCRIPTION
## Summary
- `home.nix` の `home.packages` に `serie` を追加
- README のツール一覧にも `serie` を追記

## 背景
git のコミットツリーを CLI で眺めるためのツールが欲しかったため、Rust 製の TUI である [serie](https://github.com/lusingander/serie) を選定して導入。

## 使い方
git リポジトリ内で `serie` と打つだけで起動。`?` でキーバインド一覧。

## Test plan
- [x] `home-manager switch --flake .#komusan` が成功
- [x] `serie --version` が `0.7.2` を返す
- [x] git リポジトリで `serie` を起動してコミットツリーが表示される