### PR TITLE
feat: Neovim 起動時に neo-tree を自動表示する

### DIFF
--- a/nvim/.config/nvim/lua/plugins/neo-tree.lua
+++ b/nvim/.config/nvim/lua/plugins/neo-tree.lua
@@ -1,6 +1,7 @@
 return {
   "nvim-neo-tree/neo-tree.nvim",
   branch = "v3.x",
+  lazy = false,
   dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-tree/nvim-web-devicons",
@@ -41,6 +42,12 @@ return {
         position = "left",
         width = 32,
       },
+    })
+
+    vim.api.nvim_create_autocmd("VimEnter", {
+      callback = function()
+        vim.cmd("Neotree show")
+      end,
     })
   end,
 }


### PR DESCRIPTION
## 概要
- Neovim 起動時に neo-tree のファイラを左サイドに自動表示する
- フォーカスは編集対象バッファ側に残す
- closes #73

## 背景・モチベーション
これまで neo-tree は `<leader>e` で遅延ロードされる設定だったため、起動直後はファイラが非表示で毎回手動で開く必要があった。起動時から常に開いた状態にして手間を減らす。

## 変更の詳細
- `nvim/.config/nvim/lua/plugins/neo-tree.lua`
  - `lazy = false` を追加し、起動時に常時ロードするよう変更
  - `config` 内に `VimEnter` autocmd を追加し、`Neotree show`（フォーカスを取らないコマンド）を呼ぶ
- 既存の `<leader>e`（toggle）とその他の設定はそのまま維持

## 動作確認
- [ ] `nvim` を引数なしで起動 → neo-tree が左サイドに表示され、カーソルは空バッファ側にある
- [ ] `nvim <file>` でファイル指定起動 → neo-tree が表示され、カーソルは指定ファイル側にある
- [ ] `nvim .` でディレクトリ指定起動 → neo-tree が表示される
- [ ] `<leader>e` の toggle が従来通り動作する

## 注意事項・補足
- stdin / vimdiff など特殊起動時のガードは入れていない（問題が出たら追加対応する）