### PR TITLE
feat: wezterm に開発用テンプレート起動のキーバインドを追加 (#70)

### DIFF
--- a/wezterm/.config/wezterm/keybinds.lua
+++ b/wezterm/.config/wezterm/keybinds.lua
@@ -1,49 +1,56 @@
+local templates = require "templates"
+
 local M = {}
 
 function M.apply(config, wezterm)
-	config.keys = {
-		{
-			key = "d",
-			mods = "CMD",
-			action = wezterm.action.SplitHorizontal,
-		},
-		{
-			key = "d",
-			mods = "CMD|SHIFT",
-			action = wezterm.action.SplitVertical,
-		},
-		{
-			key = "w",
-			mods = "CMD",
-			action = wezterm.action.CloseCurrentPane { confirm = true },
-		},
-		{
-			key = "f",
-			mods = "CTRL|CMD",
-			action = wezterm.action.ToggleFullScreen,
-		},
-		-- pane 移動
-		{
-			key = "h",
-			mods = "CMD|OPT",
-			action = wezterm.action.ActivatePaneDirection "Left",
-		},
-		{
-			key = "l",
-			mods = "CMD|OPT",
-			action = wezterm.action.ActivatePaneDirection "Right",
-		},
-		{
-			key = "k",
-			mods = "CMD|OPT",
-			action = wezterm.action.ActivatePaneDirection "Up",
-		},
-		{
-			key = "j",
-			mods = "CMD|OPT",
-			action = wezterm.action.ActivatePaneDirection "Down",
-		},
-	}
+  config.keys = {
+    {
+      key = "t",
+      mods = "CMD|SHIFT",
+      action = wezterm.action_callback(templates.dev),
+    },
+    {
+      key = "d",
+      mods = "CMD",
+      action = wezterm.action.SplitHorizontal,
+    },
+    {
+      key = "d",
+      mods = "CMD|SHIFT",
+      action = wezterm.action.SplitVertical,
+    },
+    {
+      key = "w",
+      mods = "CMD",
+      action = wezterm.action.CloseCurrentPane { confirm = true },
+    },
+    {
+      key = "f",
+      mods = "CTRL|CMD",
+      action = wezterm.action.ToggleFullScreen,
+    },
+    -- pane 移動
+    {
+      key = "h",
+      mods = "CMD|OPT",
+      action = wezterm.action.ActivatePaneDirection "Left",
+    },
+    {
+      key = "l",
+      mods = "CMD|OPT",
+      action = wezterm.action.ActivatePaneDirection "Right",
+    },
+    {
+      key = "k",
+      mods = "CMD|OPT",
+      action = wezterm.action.ActivatePaneDirection "Up",
+    },
+    {
+      key = "j",
+      mods = "CMD|OPT",
+      action = wezterm.action.ActivatePaneDirection "Down",
+    },
+  }
 end
 
 return M

--- a/wezterm/.config/wezterm/templates.lua
+++ b/wezterm/.config/wezterm/templates.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+-- ログインシェル経由でコマンドを起動する（PATH をユーザー環境のものにするため）
+local function login_shell_args(cmd)
+	return { "/bin/zsh", "-lc", "exec " .. cmd }
+end
+
+-- 開発用テンプレート: 左上 nvim / 左下 shell / 右 claude
+function M.dev(window)
+	local mux = window:mux_window()
+	local _, left_top, _ = mux:spawn_tab { args = login_shell_args "nvim" }
+	left_top:split { direction = "Right", size = 0.4, args = login_shell_args "claude" }
+	left_top:split { direction = "Bottom", size = 0.3 }
+end
+
+return M


### PR DESCRIPTION
## 概要
- ⌘⇧T で開発用 3pane レイアウト（nvim / shell / claude）を一発で起動するキーバインドを追加
- ログインシェル経由で起動するヘルパーを導入し PATH 解決の問題を回避

## 背景・モチベーション
Issue #70 の対応。開発開始時に毎回手動で nvim / shell / claude の 3pane レイアウトを組んでいたため、ショートカット一発で再現できるようにしたい。

実装中、`mux:spawn_tab { args = {...} }` がログインシェルを経由せず最小 PATH (`/usr/bin:/bin:...`) でプロセスを起動することが分かり、`nvim`（/opt/homebrew/bin）や `claude`（~/.local/bin）が見つからずに起動失敗する問題があったため、その回避策も同時に組み込んだ。

## 変更の詳細
- `wezterm/.config/wezterm/templates.lua` を新規追加
  - `dev` テンプレート: 左上 nvim / 左下 shell / 右 claude の 3pane を構築
  - `login_shell_args` ヘルパー: `/bin/zsh -lc "exec <cmd>"` でログインシェル経由起動。`exec` で置換することで余分なシェル層を残さず、終了時の pane 挙動を従来どおりに保つ
- `wezterm/.config/wezterm/keybinds.lua`
  - `templates` モジュールを require
  - `CMD|SHIFT + t` に `templates.dev` を割り当て
  - 既存キーバインドのインデントをタブ→スペースに整形

## 動作確認
- [x] ⌘⇧T を押下し nvim / shell / claude の 3pane レイアウトが起動することを確認
- [x] 各 pane で nvim / claude が PATH エラーなく起動することを確認
- [x] 既存のキーバインド（⌘D / ⌘⇧D / ⌘W / ⌃⌘F / pane 移動）が従来どおり動作することを確認

## 注意事項・補足
- ログインシェルとして `/bin/zsh` を直接指定している。将来 `$SHELL` を尊重したい場合は `wezterm.home_dir` 等と組み合わせて拡張可能
- Issue #70 の「将来的に複数テンプレートを選択できる形」は今回の対応範囲外（`templates.lua` がモジュール化されているので追加しやすい状態にはなっている）

Closes #70