### PR TITLE
非対話シェルで Nix の PATH が通らない問題を修正

### DIFF
--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -25,6 +25,16 @@
     # cd 関数等、Nix 式に分解しづらいシェル処理
     initContent = builtins.readFile ../zsh/zshrc-extra.sh;
 
+    # 全 zsh 起動（非対話含む）で Nix の PATH を有効化する
+    # Why: nix-installer 設置の /etc/zshrc は対話シェルのみ、/etc/zshenv は SSH 限定で
+    # nix-daemon.sh を読み込む。そのため cron / launchd / Claude Code のフック等
+    # 非対話シェルから home.packages のツール（gh / jq 等）が解決できない (#59)。
+    envExtra = ''
+      if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+        . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+      fi
+    '';
+
     # ログインシェルでのみ実行する Homebrew 環境設定
     profileExtra = ''
       eval "$(/opt/homebrew/bin/brew shellenv)"


### PR DESCRIPTION
## 概要
- `programs.zsh.envExtra` で `.zshenv` から `nix-daemon.sh` を source する処理を追加
- 非対話シェル（cron / launchd / Claude Code のフック等）からも `home.packages` のツールが PATH 解決できるようにする

## 背景・モチベーション
nix-installer が設置するシステムファイルの構成上、Nix 由来 PATH はインタラクティブシェル（`/etc/zshrc`）または SSH 接続時の `.zshenv`（`/etc/zshenv` の `SSH_CONNECTION` ガード）でしか有効にならない。

そのため非対話シェルから `gh` / `jq` 等の home-manager 管理ツールが `command not found` になる問題が発生していた。Phase 2 (#52) で純 CLI ツールを Brew から `home.packages` に移行した結果、この潜在問題が顕在化した。

Closes #59

## 変更の詳細
- `modules/zsh.nix`: `programs.zsh.envExtra` を新規追加し、`/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` を冪等に source する
- `nix-daemon.sh` 自体に `__ETC_PROFILE_NIX_SOURCED` ガードがあるため、対話シェル側 `/etc/zshrc` との二重ソースは無害

## 動作確認
- [x] `home-manager switch --flake .#komusan` 適用成功
- [x] `nix flake check` 通過
- [x] 生成された `~/.config/zsh/.zshenv` に nix-daemon.sh のソース処理が含まれる
- [x] 素の非対話 zsh（`__ETC_PROFILE_NIX_SOURCED` を unset 後）で `gh` がフルパス無しで解決可能

## 注意事項・補足
- 既に対話シェルで `__ETC_PROFILE_NIX_SOURCED=1` が export 済みの環境から子プロセスを起こす場合、既存挙動に影響なし（冪等ガードで no-op）
- 真に非対話な場面（cron / launchd / 新規シェル）で初めて差分が効く