### PR TITLE
feat: lazygit を programs.lazygit で宣言管理し delta を統合

### DIFF
--- a/git/git.nix
+++ b/git/git.nix
@@ -2,6 +2,19 @@
 # git 設定
 # 旧 git/.config/git/config と git/.config/git/ignore を programs.git で宣言的に管理
 {
+  # delta を git の pager として有効化
+  # これにより `git diff` / `git show` / lazygit の差分表示が syntax highlight 付きになる
+  programs.delta = {
+    enable = true;
+    enableGitIntegration = true;
+    options = {
+      navigate = true;       # n/N で diff セクション間を移動
+      light = false;         # ダークテーマ
+      line-numbers = true;   # 行番号を表示
+      side-by-side = false;  # まずは縦表示（必要なら true へ）
+    };
+  };
+
   programs.git = {
     enable = true;
 

--- a/home.nix
+++ b/home.nix
@@ -9,6 +9,7 @@
     ./git/git.nix
     ./starship/starship.nix
     ./direnv/direnv.nix
+    ./lazygit/lazygit.nix
   ];
 
   # home.username / home.homeDirectory は flake.nix の mkHome から注入される
@@ -22,7 +23,6 @@
     eza
     gh
     jq
-    lazygit
     lua54Packages.luacheck
     nh
     railway

--- a/lazygit/lazygit.nix
+++ b/lazygit/lazygit.nix
@@ -30,6 +30,19 @@
         editPreset = "nvim";
       };
 
+      # diff 表示を delta に委譲
+      # lazygit 0.61+ では git.paging は git.pagers 配列に変更された
+      # useConfig は git の core.pager しか参照せず、delta は pager.diff 等にしか入らないため
+      # pager を明示する。delta 自体のオプション（line-numbers/navigate 等）は ~/.config/git/config の [delta] から読まれる
+      git = {
+        pagers = [
+          {
+            colorArg = "always";
+            pager = "delta --paging=never";
+          }
+        ];
+      };
+
       # 3. Nix 管理なので lazygit 自身の自動アップデートは無効化
       update = {
         method = "never";

--- a/lazygit/lazygit.nix
+++ b/lazygit/lazygit.nix
@@ -1,0 +1,39 @@
+{ ... }:
+# lazygit 設定
+# https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
+{
+  programs.lazygit = {
+    enable = true;
+
+    settings = {
+      # 1. Catppuccin Frappe テーマ（starship と配色を統一）
+      #    https://github.com/catppuccin/lazygit
+      gui = {
+        theme = {
+          activeBorderColor = [ "#8caaee" "bold" ];   # blue
+          inactiveBorderColor = [ "#a5adce" ];        # subtext0
+          optionsTextColor = [ "#8caaee" ];           # blue
+          selectedLineBgColor = [ "#414559" ];        # surface0
+          cherryPickedCommitBgColor = [ "#51576d" ];  # surface1
+          cherryPickedCommitFgColor = [ "#babbf1" ];  # lavender
+          unstagedChangesColor = [ "#e78284" ];       # red
+          defaultFgColor = [ "#c6d0f5" ];             # text
+          searchingActiveBorderColor = [ "#e5c890" ]; # yellow
+        };
+        authorColors = {
+          "*" = "#ca9ee6"; # mauve
+        };
+      };
+
+      # 2. エディタを nvim に固定（`e` キー・コミットメッセージ編集で nvim が開く）
+      os = {
+        editPreset = "nvim";
+      };
+
+      # 3. Nix 管理なので lazygit 自身の自動アップデートは無効化
+      update = {
+        method = "never";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## 概要
- lazygit を `home.packages` から `programs.lazygit` モジュールへ移行（Catppuccin Frappe テーマ / editor=nvim / 自動更新無効）
- `programs.delta` を有効化し、`git diff` / `git show` および lazygit の diff 表示で delta を pager として使用

## 背景・モチベーション
- lazygit のテーマ・editor・自動更新方針を Nix で宣言的に固定したかった
- diff の視認性を上げるため delta による syntax highlight・行番号表示を導入したかった

## 変更の詳細
- `lazygit/lazygit.nix` を新規作成し `home.nix` から import、`home.packages` の `lazygit` を削除（モジュール側で導入されるため重複排除）
- `git/git.nix` に `programs.delta`（`enableGitIntegration = true`）を追加し、navigate / line-numbers / dark テーマを設定
- lazygit 0.61 で `git.paging` が `git.pagers` 配列に変更されたため新スキーマで記述
- lazygit 側は `useConfig` ではなく `pager = "delta --paging=never"` を明示。`enableGitIntegration` は `pager.diff` 等にしか書き込まず、`useConfig` が参照する `core.pager` には入らないため

## 動作確認
- [x] `home-manager switch --flake .#komusan` が成功する
- [x] `git diff HEAD` で delta による色付き・行番号付きの diff が表示される
- [x] `lazygit` をターミナルから直接起動して TUI が開く（旧スキーマによるマイグレーション失敗が解消）
- [x] nvim で `<leader>gg` から lazygit が開く
- [x] lazygit のファイル選択時の右ペイン diff が delta スタイルで表示される

## 注意事項・補足
- delta のオプション（`navigate` / `line-numbers` / `light` / `side-by-side`）は `~/.config/git/config` の `[delta]` セクションに書かれ、lazygit からも同セクションが読まれる