### PR TITLE
docs: 複数マシン運用の手順を README に追記 (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,14 @@ rm -rf ~/.claude/skills
 
 ### 3. home-manager の実行
 
+マシン（macOS ユーザー名）に合わせて `.#<user>` を切り替えます。
+
 ```sh
+# 個人 Mac
 nix run home-manager/master -- switch --flake .#komusan -b backup
+
+# 社用 Mac
+nix run home-manager/master -- switch --flake .#masatokomukai -b backup
 ```
 
 `-b backup` を付けると衝突したファイルを `<path>.backup` に退避してくれます。
@@ -192,8 +198,26 @@ find ~ -maxdepth 4 -name '*.backup.*' -exec rm -rf {} +
 設定変更後は以下で適用します（`-b backup` は初回のみ必要）。
 
 ```sh
-home-manager switch --flake .#komusan
+home-manager switch --flake .#komusan        # 個人 Mac
+home-manager switch --flake .#masatokomukai  # 社用 Mac
 ```
+
+## 複数マシン対応
+
+`flake.nix` の `mkHome` ヘルパーで `home.username` / `home.homeDirectory` を注入しているため、`homeConfigurations` にユーザー名を追加するだけで新しいマシンに対応できます。
+
+```nix
+# flake.nix
+homeConfigurations = {
+  komusan = mkHome "komusan";
+  masatokomukai = mkHome "masatokomukai";
+  # 新規マシン追加時はここに 1 行足す
+};
+```
+
+追加後は `home-manager switch --flake .#<新ユーザー名>` で適用します。`home.nix` 側はマシン非依存なので変更不要です。
+
+個人/会社で分岐したい設定（git identity 等）は次節「複数 Git アカウントの切替」を参照してください。
 
 ## 複数 Git アカウントの切替
 


### PR DESCRIPTION
## 概要
- README に複数マシン（個人 Mac / 社用 Mac）での `home-manager switch` 手順を追記
- `mkHome` ヘルパーへのユーザー追加方法を記載した「複数マシン対応」節を新設

## 背景・モチベーション
- Issue #57 の残タスクとして README への複数マシン運用手順の追記が未対応だった
- `flake.nix` 側のパラメータ化（`mkHome`）と `home.nix` からの `home.username` / `home.homeDirectory` 削除は実装済みだが、READMEには `.#komusan` のみが記載されており、社用 Mac での適用方法・新規マシン追加時の流れが分からない状態だった

## 変更の詳細
- セットアップ手順「3. home-manager の実行」「4. 通常運用」に `masatokomukai`（社用 Mac）の例を併記
- 「複数マシン対応」節を新設し、`flake.nix` の `mkHome` でユーザーを 1 行追加すれば対応できる旨を記載

## 動作確認
- [x] README の Markdown が崩れていないこと
- [x] `home-manager switch --flake .#komusan` / `home-manager switch --flake .#masatokomukai` のいずれもコマンドとして正しいこと（`flake.nix` で両方の `homeConfigurations` が定義済み）

## 注意事項・補足
- 本 PR で Issue #57 はクローズ可能
- 個人/会社の git identity 切替（#47）は別仕組みで既に運用中であり、本 PR からは「複数 Git アカウントの切替」節へ誘導するだけに留める

Closes #57