### PR TITLE
feat: キャッシュクリーンアップスクリプトを追加 (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ home-manager (Nix) への移行は段階的に進行中で、Phase 1 ([#51](http
 ├── zsh/
 │   ├── zsh.nix                   # programs.zsh 宣言（alias / history / sessionPath / profileExtra）
 │   └── zshrc-extra.sh            # programs.zsh.initContent から readFile で取り込み
+├── scripts/
+│   └── cleanup-caches.sh        # 開発ツールのキャッシュ一括クリーンアップ
 └── claude/
     ├── claude.nix                # mkOutOfStoreSymlink で ~/.claude/ 配下を個別にリンク
     └── .claude/                  # ※ ~/.claude/ 全体は symlink せず、配下を個別にリンク
@@ -285,6 +287,21 @@ direnv allow
 ```
 
 `cd` するだけで該当プロジェクト用のランタイムが有効化されます。
+
+## メンテナンススクリプト
+
+`scripts/` 配下に手動実行のメンテナンス用ユーティリティを置いています。
+
+| スクリプト | 用途 |
+|---|---|
+| `scripts/cleanup-caches.sh` | 開発ツール（npm / gradle / docker / cargo）のキャッシュを一括クリーンアップ。`--dry-run` で削除前のサイズだけ確認可能 |
+
+```sh
+./scripts/cleanup-caches.sh --dry-run   # 確認のみ
+./scripts/cleanup-caches.sh             # 実際にクリーンアップ
+```
+
+導入されていないツールは自動でスキップされます。
 
 ## 補足: 個別ツールの方針
 

--- a/scripts/cleanup-caches.sh
+++ b/scripts/cleanup-caches.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# 開発ツールのキャッシュ（npm / gradle / docker / cargo）を一括クリーンアップする。
+# インストール済みのツールのみ処理する。
+# Usage: cleanup-caches.sh [--dry-run]
+
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n) DRY_RUN=1 ;;
+    --help|-h)
+      cat <<EOF
+Usage: $(basename "$0") [--dry-run]
+
+開発ツールのキャッシュ（npm / gradle / docker / cargo）をクリーンアップする。
+インストール済みのツールのみ処理する。
+
+Options:
+  --dry-run, -n  実際の削除を行わず、対象と現在のサイズのみ表示
+  --help, -h     このヘルプを表示
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# 色付け（TTY のときのみ）
+if [ -t 1 ]; then
+  C_GREEN=$'\033[32m'
+  C_YELLOW=$'\033[33m'
+  C_BLUE=$'\033[34m'
+  C_BOLD=$'\033[1m'
+  C_RESET=$'\033[0m'
+else
+  C_GREEN=''
+  C_YELLOW=''
+  C_BLUE=''
+  C_BOLD=''
+  C_RESET=''
+fi
+
+section() {
+  printf '\n%s==> %s%s\n' "${C_BOLD}${C_BLUE}" "$1" "${C_RESET}"
+}
+warn() {
+  printf '%s%s%s\n' "${C_YELLOW}" "$1" "${C_RESET}" >&2
+}
+ok() {
+  printf '%s✓ %s%s\n' "${C_GREEN}" "$1" "${C_RESET}"
+}
+
+# ディレクトリサイズ（du -sh の値、存在しなければ "0"）
+dir_size() {
+  if [ -d "$1" ]; then
+    du -sh "$1" 2>/dev/null | awk '{print $1}'
+  else
+    echo "0"
+  fi
+}
+
+cleanup_npm() {
+  if ! command -v npm >/dev/null 2>&1; then
+    warn "npm が見つかりません。スキップします。"
+    return
+  fi
+  local cache_dir before after
+  cache_dir=$(npm config get cache 2>/dev/null || echo "$HOME/.npm")
+  before=$(dir_size "$cache_dir")
+  echo "対象: $cache_dir (現在 $before)"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  [dry-run] npm cache verify は実行しません"
+    return
+  fi
+  npm cache verify
+  after=$(dir_size "$cache_dir")
+  ok "npm: $before → $after"
+}
+
+cleanup_gradle() {
+  if ! command -v gradle >/dev/null 2>&1 && [ ! -d "$HOME/.gradle" ]; then
+    warn "gradle が見つかりません。スキップします。"
+    return
+  fi
+  local cache_dir="$HOME/.gradle"
+  local before after
+  before=$(dir_size "$cache_dir")
+  echo "対象: $cache_dir (現在 $before)"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  [dry-run] gradle --stop は実行しません"
+    return
+  fi
+  if command -v gradle >/dev/null 2>&1; then
+    gradle --stop || true
+  fi
+  echo "  ※ gradle 4.10+ の自動 TTL で古いキャッシュは順次削除されます"
+  after=$(dir_size "$cache_dir")
+  ok "gradle: $before → $after"
+}
+
+cleanup_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    warn "docker が見つかりません。スキップします。"
+    return
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    warn "docker デーモンが起動していません。スキップします。"
+    return
+  fi
+  echo "対象: docker system"
+  docker system df || true
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  [dry-run] docker system prune は実行しません"
+    return
+  fi
+  docker system prune -f
+  ok "docker: prune 完了"
+}
+
+cleanup_cargo() {
+  if [ ! -d "$HOME/.cargo" ]; then
+    warn "cargo が見つかりません。スキップします。"
+    return
+  fi
+  local cache_dir="$HOME/.cargo"
+  local before after
+  before=$(dir_size "$cache_dir")
+  echo "対象: $cache_dir (現在 $before)"
+  if ! command -v cargo-cache >/dev/null 2>&1; then
+    warn "  cargo-cache 未導入。\`cargo install cargo-cache\` で利用可能"
+    return
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  [dry-run] cargo cache --autoclean は実行しません"
+    return
+  fi
+  cargo cache --autoclean
+  after=$(dir_size "$cache_dir")
+  ok "cargo: $before → $after"
+}
+
+# ── 実行 ──────────────────────────────────────────
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '%sキャッシュクリーンアップ (dry-run モード)%s\n' "${C_BOLD}" "${C_RESET}"
+else
+  printf '%sキャッシュクリーンアップ%s\n' "${C_BOLD}" "${C_RESET}"
+fi
+echo "開始: $(date '+%Y-%m-%d %H:%M:%S')"
+
+section "npm"
+cleanup_npm
+section "gradle"
+cleanup_gradle
+section "docker"
+cleanup_docker
+section "cargo"
+cleanup_cargo
+
+echo ""
+printf '%s完了%s: %s\n' "${C_BOLD}" "${C_RESET}" "$(date '+%Y-%m-%d %H:%M:%S')"


### PR DESCRIPTION
## 概要
- 開発ツール（npm / gradle / docker / cargo）のキャッシュを一括クリーンアップする `scripts/cleanup-caches.sh` を新設
- README.md にリポジトリ構成と利用方法を追記

## 背景・モチベーション
パッケージマネージャは基本的に「消さない」設計のため、放置すると `$HOME` 配下のキャッシュが膨張し続ける（過去調査時点で .rustup 2.5GB / .npm 2.9GB / .gradle 725MB 等）。明示的な運用としてクリーンアップ用ユーティリティを dotfiles に持ち込み、月 1 程度の手動実行で運用できるようにする。

Closes #48

## 変更の詳細
- `scripts/` ディレクトリを新設（手動実行のメンテナンス用ユーティリティ置き場）
- `scripts/cleanup-caches.sh`:
  - `--dry-run` / `-n` で削除を行わず現状サイズだけ表示
  - 各ツールは `command -v` で導入検出し、未導入の場合はスキップ
  - 実行前後のサイズを `du -sh` で表示
  - 各ツールの処理: npm → `npm cache verify`、gradle → `gradle --stop`（自動 TTL に委譲）、docker → `docker system df` + `docker system prune -f`、cargo → `cargo cache --autoclean`（要 cargo-cache プラグイン）
- README.md: リポジトリ構成ツリーに `scripts/` を追加し、独立した「メンテナンススクリプト」セクションで利用例を提示

## 動作確認
- [x] `shellcheck --severity=warning scripts/cleanup-caches.sh` が通る
- [x] `scripts/cleanup-caches.sh --dry-run` が想定どおり動作（npm / docker は対象を表示し、未導入の gradle / cargo はスキップ）
- [x] `/check`（ShellCheck / Luacheck / SKILL.md / nixfmt / statix / home-manager build）の全 6 項目 PASS

## 注意事項・補足
- launchd / cron による定期実行は今回スコープ外。運用が定着してから別 Issue で検討
- cargo は `cargo-cache` プラグイン（`cargo install cargo-cache`）が前提。未導入時は警告を出してスキップ