### PR TITLE
feat(nvim): image.nvim を追加して画像プレビューとズーム操作を実現

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ home-manager (Nix) への移行は段階的に進行中で、Phase 1 ([#51](http
 | [tokyonight.nvim](https://github.com/folke/tokyonight.nvim) | カラースキーム（青系モダン） | `plugins/colorscheme.lua` |
 | [vim-moonfly-colors](https://github.com/bluz71/vim-moonfly-colors) | カラースキーム（デフォルト） | `plugins/colorscheme.lua` |
 | [vim-illuminate](https://github.com/RRethy/vim-illuminate) | カーソル下の単語をハイライト | `plugins/illuminate.lua` |
+| [image.nvim](https://github.com/3rd/image.nvim) | バッファ内画像プレビュー（PNG/JPG/GIF/WebP）。`+`/`-` でズーム、`0` でリセット | `plugins/image.lua` |
 
 ## リポジトリ構成
 

--- a/home.nix
+++ b/home.nix
@@ -22,6 +22,7 @@
     cowsay
     eza
     gh
+    imagemagick
     jq
     lua54Packages.luacheck
     nh

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -12,6 +12,8 @@
   "github-theme": { "branch": "main", "commit": "c106c9472154d6b2c74b74565616b877ae8ed31d" },
   "gitsigns.nvim": { "branch": "main", "commit": "dd3f588bacbeb041be6facf1742e42097f62165d" },
   "gruvbox-material": { "branch": "master", "commit": "11d779b26a9ab2b3db8c22c6ac9fb6e8ed4fea79" },
+  "hererocks": { "branch": "master", "commit": "3db37265c3839cbd4d27fc73f92fa7b58bc3a76f" },
+  "image.nvim": { "branch": "master", "commit": "da2be65c153ba15a14a342b05591652a6df70d58" },
   "kanagawa.nvim": { "branch": "master", "commit": "8ad3b4cdcc804b332c32db8f9743667e1bb82b99" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "lualine.nvim": { "branch": "master", "commit": "131a558e13f9f28b15cd235557150ccb23f89286" },

--- a/nvim/.config/nvim/lua/plugins/image.lua
+++ b/nvim/.config/nvim/lua/plugins/image.lua
@@ -1,0 +1,86 @@
+return {
+  "3rd/image.nvim",
+  lazy = false,
+  opts = {
+    backend = "sixel",
+    processor = "magick_cli",
+    integrations = {
+      markdown = {
+        enabled = true,
+        clear_in_insert_mode = false,
+        download_remote_images = true,
+        only_render_image_at_cursor = false,
+        filetypes = { "markdown", "vimwiki" },
+      },
+      neorg = { enabled = false },
+      typst = { enabled = false },
+      html = { enabled = false },
+      css = { enabled = false },
+    },
+    max_width = nil,
+    max_height = nil,
+    max_width_window_percentage = nil,
+    max_height_window_percentage = 50,
+    window_overlap_clear_enabled = true,
+    window_overlap_clear_ft_ignore = { "cmp_menu", "cmp_docs", "snacks_notif", "scrollview", "scrollview_sign" },
+    editor_only_render_when_focused = false,
+    tmux_show_only_in_active_window = false,
+    hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.avif" },
+  },
+  config = function(_, opts)
+    require("image").setup(opts)
+
+    local original_size = {}
+
+    local function get_buf_images()
+      return require("image").get_images({ buffer = vim.api.nvim_get_current_buf() })
+    end
+
+    local function current_size(img)
+      local rg = img.rendered_geometry or {}
+      local w = img.geometry.width or rg.width or 0
+      local h = img.geometry.height or rg.height or 0
+      return w, h
+    end
+
+    local function zoom(factor)
+      return function()
+        for _, img in ipairs(get_buf_images()) do
+          local w, h = current_size(img)
+          if w > 0 and h > 0 then
+            if not original_size[img.id] then
+              original_size[img.id] = { width = w, height = h }
+            end
+            img.ignore_global_max_size = true
+            img:render({
+              width = math.max(1, math.floor(w * factor)),
+              height = math.max(1, math.floor(h * factor)),
+            })
+          end
+        end
+      end
+    end
+
+    local function reset()
+      for _, img in ipairs(get_buf_images()) do
+        local saved = original_size[img.id]
+        if saved then
+          img.ignore_global_max_size = false
+          img:render({ width = saved.width, height = saved.height })
+        end
+      end
+    end
+
+    vim.api.nvim_create_autocmd("BufReadPost", {
+      pattern = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp", "*.avif" },
+      callback = function(args)
+        local map = function(lhs, rhs, desc)
+          vim.keymap.set("n", lhs, rhs, { buffer = args.buf, desc = desc })
+        end
+        map("+", zoom(1.1), "Image: zoom in")
+        map("-", zoom(0.9), "Image: zoom out")
+        map("0", reset, "Image: reset zoom")
+      end,
+    })
+  end,
+}

--- a/nvim/.config/nvim/lua/plugins/init.lua
+++ b/nvim/.config/nvim/lua/plugins/init.lua
@@ -21,6 +21,7 @@ require("lazy").setup({
   { import = "plugins.swenv" },
   { import = "plugins.ruby" },
   { import = "plugins.illuminate" },
+  { import = "plugins.image" },
 }, {
   checker = { enabled = false },
   change_detection = { notify = false },


### PR DESCRIPTION
## 概要
- Neovim 上でバッファ内に画像をプレビューできるようにする
- `+` / `-` でズームイン・アウト、`0` で初期サイズに戻す画像バッファローカルキーマップを追加
- WezTerm 互換性のため image.nvim の backend は sixel を採用

## 背景・モチベーション
Issue #72 のとおり、Neovim で画像ファイルを開くとバイナリ表示になり中身を確認するために `open` / Finder へ抜ける必要があった。WezTerm が画像表示プロトコルに対応しているため、エディタ内でプレビューできれば作業効率が改善する。

## 変更の詳細
- `nvim/.config/nvim/lua/plugins/image.lua` を新規追加
  - `3rd/image.nvim` を `lazy = false` で登録
  - backend は `sixel`（WezTerm の Kitty graphics protocol 実装は非互換があり「一瞬表示されて消える」症状が出るため、sixel が安定）
  - processor は `magick_cli`（LuaRock 不要、ImageMagick CLI のみで動作）
  - `hijack_file_patterns` に PNG / JPG / GIF / WebP / AVIF を指定し `:edit` で直接プレビュー
  - `BufReadPost` autocmd で画像バッファに `+` / `-` / `0` のローカルキーマップを設定
  - ズーム実装は `image.nvim` の `:render({ width, height })` を 1.1 倍ステップで呼び出し、`ignore_global_max_size = true` で `max_height_window_percentage` の clamp を回避
  - リセットは初期サイズを `image.id` 単位でメモリし、`:render()` で復元
- `nvim/.config/nvim/lua/plugins/init.lua` に `plugins.image` の import を追加
- `home.nix` の `home.packages` に `imagemagick` を追加（sixel エンコーディングおよび `magick_cli` processor の依存）
- `README.md` のプラグイン一覧に `image.nvim` 行を追加

## 動作確認
- [x] `home-manager switch --flake .#komusan` で適用
- [x] Neovim を再起動して neo-tree から PNG / JPG ファイルを選択 → プレビュー表示されること
- [x] `nvim foo.png` で起動した場合も初回からプレビュー表示されること
- [x] 画像バッファで `+` を押すと拡大、`-` で縮小、`0` で初期サイズに戻ること
- [x] `/check` ですべてのローカル CI チェックが PASS すること（shellcheck / luacheck / SKILL.md / nixfmt / statix / home-manager build）

## 注意事項・補足
- backend に `sixel` を選んだ経緯: `kitty` backend だと WezTerm の compliance 不足で「一瞬表示されて消える」症状が再現したため。`sixel` は backend 内に flush メカニズムを持ち redraw 耐性が高い。
- `lazy = false` は `nvim foo.png` で起動した場合に hijack autocmd が BufWinEnter より先に登録されている必要があるため。
- `imagemagick` は sixel エンコーディングおよび `magick_cli` processor の必須依存。

Closes #72