### PR TITLE
feat(docker): Docker Desktop から Colima へ移行して home-manager で管理

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,3 @@
-brew "colima"
-brew "docker"
-brew "docker-compose"
 brew "jenkins-lts", restart_service: :changed
 brew "libpq", link: true
 brew "mysql-client"

--- a/docker/docker.nix
+++ b/docker/docker.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, ... }:
+# Docker CLI 関連の設定
+#
+# macOS 上での Docker ランタイムは Docker Desktop ではなく Colima を使う。
+# docker / docker-compose / docker-buildx / colima を nixpkgs から導入し、
+# DOCKER_CONFIG を XDG 配下（~/.config/docker）に固定する。
+#
+# `docker compose` / `docker buildx` は CLI プラグイン方式で動くため、
+# nixpkgs の libexec パスを ~/.config/docker/cli-plugins/ にリンクする。
+{
+  home.sessionVariables = {
+    DOCKER_CONFIG = "${config.xdg.configHome}/docker";
+  };
+
+  home.packages = with pkgs; [
+    docker-client
+    docker-compose
+    docker-buildx
+    colima
+  ];
+
+  xdg.configFile = {
+    "docker/cli-plugins/docker-compose".source =
+      "${pkgs.docker-compose}/libexec/docker/cli-plugins/docker-compose";
+    "docker/cli-plugins/docker-buildx".source =
+      "${pkgs.docker-buildx}/libexec/docker/cli-plugins/docker-buildx";
+  };
+}

--- a/home.nix
+++ b/home.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ./nix/modules/shell-env.nix
+    ./docker/docker.nix
     ./nvim/nvim.nix
     ./wezterm/wezterm.nix
     ./claude/claude.nix

--- a/nix/modules/shell-env.nix
+++ b/nix/modules/shell-env.nix
@@ -21,6 +21,6 @@
     # 言語ランタイム/CLI のキャッシュ・設定を XDG 配下へ
     NPM_CONFIG_CACHE = "${config.xdg.cacheHome}/npm";
     GRADLE_USER_HOME = "${config.xdg.dataHome}/gradle";
-    DOCKER_CONFIG = "${config.xdg.configHome}/docker";
+    # DOCKER_CONFIG は docker パッケージ群と併せて docker/docker.nix で管理
   };
 }


### PR DESCRIPTION
## 概要
- macOS の Docker ランタイムを Docker Desktop から Colima に移行
- docker / docker-compose / docker-buildx / colima を nixpkgs 経由で導入
- DOCKER_CONFIG と cli-plugins のリンクを `docker/docker.nix` に集約

## 背景・モチベーション
これまで `docker` CLI は Docker Desktop に同梱されたバイナリ（`/usr/local/bin/docker` → `/Applications/Docker.app/...`）に依存していた。一方で Brewfile にはすでに `colima` / `docker` / `docker-compose` が記載されていたものの未インストールで、実態と宣言が乖離していた。`DOCKER_CONFIG=~/.config/docker` を設定しているのに cli-plugins を XDG 配下に置いていなかったため `docker compose` サブコマンドも解決できない状態だった。

これを機に Docker Desktop を廃止して Colima 中心の運用に切り替え、CLI ツール一式は dotfiles 方針通り nix で管理するようにする。

## 変更の詳細
- `docker/docker.nix` を新規作成
  - `home.packages` に `docker-client` / `docker-compose` / `docker-buildx` / `colima` を追加
  - `DOCKER_CONFIG = ${xdg.configHome}/docker` を設定
  - `xdg.configFile` で nix store の `libexec/docker/cli-plugins/{docker-compose,docker-buildx}` を `~/.config/docker/cli-plugins/` にリンク
- `home.nix` の `imports` に `./docker/docker.nix` を追加
- `nix/modules/shell-env.nix` から `DOCKER_CONFIG` 行を削除（責務を `docker/docker.nix` に移動）
- `Brewfile` から `docker` / `docker-compose` / `colima` を削除

## 動作確認
- [x] `home-manager switch --flake .#masatokomukai` がエラーなく完了
- [x] `~/.nix-profile/bin/{docker,docker-compose,docker-buildx,colima}` が nix store を指している
- [x] `~/.config/docker/cli-plugins/{docker-compose,docker-buildx}` が nix store の libexec を指している
- [x] Docker Desktop を公式 uninstall + 残骸（`/Applications/Docker.app`, `/Library/PrivilegedHelperTools/com.docker.socket`, `/Library/LaunchDaemons/com.docker.socket.plist`, `/var/run/docker.sock`）を削除
- [x] `colima start` で VM が起動し `colima` コンテキストがアクティブ
- [x] `docker version` で Client 29.4.1 / Server 29.2.1（Linux/arm64）が表示
- [x] `docker compose version` / `docker buildx version` が正常応答
- [x] `docker run --rm hello-world` が完走

## 注意事項・補足
- このリポジトリを既に適用済みのマシンで切り替える際は、Docker Desktop のアンインストール（公式 uninstall + 残骸削除）が別途必要
- `~/Library/Containers/com.docker.docker` 配下は macOS の App Sandbox 管理下で sudo でも削除できないため残置（必要なら Finder からゴミ箱経由で削除）
- `~/.docker/config.json`（Docker Desktop 由来）は今回未削除。`DOCKER_CONFIG` が `~/.config/docker` を指すため実害はない