### PR TITLE
chore: Claude / Neovim / Docker まわりの設定更新

### DIFF
--- a/docker/docker.nix
+++ b/docker/docker.nix
@@ -7,6 +7,12 @@
 #
 # `docker compose` / `docker buildx` は CLI プラグイン方式で動くため、
 # nixpkgs の libexec パスを ~/.config/docker/cli-plugins/ にリンクする。
+#
+# 運用注意:
+# - Homebrew で docker / docker-compose / docker-buildx / colima を入れないこと
+#   （Brewfile にも追加しない）。Homebrew 版の docker は config パスや CLI プラグイン
+#   検索パスの扱いが nix と噛み合わず、`docker compose` のサブコマンドが見えなくなる。
+# - 変更後は `home-manager switch --flake .#<user>` の再適用を忘れずに。
 {
   home.sessionVariables = {
     DOCKER_CONFIG = "${config.xdg.configHome}/docker";


### PR DESCRIPTION
## 概要
- Claude Code に supabase プラグインを追加
- release スキルを PR ベースの 2 フェーズ運用に刷新
- Neovim プラグインの lazy-lock.json を更新
- docker.nix に Homebrew 併用時の注意コメントを追記

## 背景・モチベーション
日常的な設定アップデートと、リリース運用の改善が目的。
- Supabase 連携を Claude Code から扱えるようにする
- release スキルを `develop → release ブランチ → main への PR → マージ後にタグ + develop へバックマージ` の 2 フェーズ式に変えて、レビューを挟める運用にする
- nvim プラグインのバージョンを最新の lock 状態に揃える
- docker は nix で一元管理する方針なので、Homebrew で同等パッケージを入れると `docker compose` のサブコマンドが解決できなくなるハマりどころを `docker/docker.nix` の冒頭に残しておく

## 変更の詳細
- `claude/.claude/settings.json`: `enabledPlugins` に `supabase@claude-plugins-official` を追加。キー順を整理
- `claude/.claude/skills/release/SKILL.md`: フェーズ判定ロジック・Phase 1 (release ブランチ作成 + main への PR)・Phase 2 (タグ付与 + develop バックマージ + release ブランチ削除) に再構成。`ALLOW_PROTECTED_PUSH=1` の使い方や禁止事項も明記
- `docker/docker.nix`: Homebrew で docker / docker-compose / docker-buildx / colima を入れない旨と、変更後に `home-manager switch` を再適用する旨をヘッダコメントに追記
- `nvim/.config/nvim/lazy-lock.json`: LuaSnip / alpha-nvim / barbar.nvim / conform.nvim / gitsigns.nvim / lualine.nvim / mason* / moonfly / neo-tree.nvim / nvim-cmp / nvim-dap* / nvim-lspconfig / nvim-treesitter / nvim-web-devicons / plenary.nvim / telescope.nvim / vim-test を更新

## 動作確認
- [ ] `home-manager switch --flake .#komusan` が通る
- [ ] Neovim 起動時に lazy-lock.json の差分が安定している
- [ ] Claude Code で supabase プラグインがロードされる
- [ ] `/release` スキルでフェーズ判定が期待通りに動く（dry-run でも可）

## 注意事項・補足
- release スキルの仕様変更はワークフロー自体に影響するので、初回利用時は Phase 1 → PR レビュー → マージ → Phase 2 の流れで動かして挙動を確認する
- Homebrew 側に既に docker 系が入っている環境では、別途アンインストールが必要