### PR TITLE
Forgejo CLI tea 追加・Claude TUI 全画面化・markdown プレビューキーマップ追加

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -13,5 +13,6 @@
     "supabase@claude-plugins-official": true
   },
   "theme": "auto",
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "tui": "fullscreen"
 }

--- a/home.nix
+++ b/home.nix
@@ -34,6 +34,7 @@
     shellcheck
     statix
     stylua
+    tea
   ];
 
   # fzf を有効化（programs.zsh と組み合わせて .zshrc に統合コードを自動挿入）

--- a/nvim/.config/nvim/lua/plugins/markdown-preview.lua
+++ b/nvim/.config/nvim/lua/plugins/markdown-preview.lua
@@ -2,6 +2,9 @@ return {
   "iamcco/markdown-preview.nvim",
   cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
   ft = { "markdown" },
+  keys = {
+    { "<leader>mp", "<Cmd>MarkdownPreviewToggle<CR>", ft = "markdown", desc = "Markdown Preview Toggle" },
+  },
   build = "cd app && npm install",
   config = function()
     vim.g.mkdp_auto_start = 1


### PR DESCRIPTION
## 概要
develop に対する 3 件の設定・ツール追加。

- Forgejo CLI `tea` を Nix 管理下に追加
- Claude Code を全画面 TUI 表示に設定
- Neovim の markdown プレビューにトグルキーマップ `<leader>mp` を追加

## 背景・モチベーション
- Forgejo 操作を CLI で完結させるため `tea` を home.packages で管理したい
- Claude Code を全画面表示で使いたい
- markdown プレビュー起動が `:MarkdownPreview` のコマンド手打ちでわかりづらかったため、発見しやすいキーマップを用意する

## 変更の詳細
- `home.nix`: `tea` を home.packages に追加
- `claude/.claude/settings.json`: `"tui": "fullscreen"` を追加
- `nvim/.config/nvim/lua/plugins/markdown-preview.lua`: markdown ファイル用に `<leader>mp` → `MarkdownPreviewToggle` のキーマップを追加（既存 `keys` 規約に準拠）

## 動作確認
- [ ] `home-manager switch --flake .#komusan` が成功する
- [ ] `tea --version` が実行できる
- [ ] markdown ファイルで `<leader>mp` によりプレビューがトグルできる

## 注意事項・補足
- markdown プレビューは `mkdp_auto_start = 1` のままのため、ファイルを開くと自動起動する点は従来通り。