### PR TITLE
chore: home.packages に cfn-lint を追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -29,6 +29,7 @@
     lua54Packages.luacheck
     nh
     nixfmt
+    python3Packages.cfn-lint
     railway
     serie
     shellcheck


### PR DESCRIPTION
## 概要
- `home.packages` に CloudFormation テンプレートの Linter である `cfn-lint` を追加

## 背景・モチベーション
CloudFormation テンプレートの記述・検証を行うため、CLI ツールとして `cfn-lint` を開発環境に常備する。

## 変更の詳細
- `home.nix` の `home.packages` に `python3Packages.cfn-lint` を追加

## 動作確認
- [ ] `home-manager switch --flake .#komusan` が成功する
- [ ] `cfn-lint --version` が実行できる

## 注意事項・補足
特になし