### PR TITLE
プロジェクトジャンプ関数 pj を追加（fd 導入）

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ macOS 向けの開発環境設定ファイル（dotfiles）を管理するリポ
 - **Neovim** - テキストエディタ（Lazy.nvim, LSP, Treesitter, Neo-tree 等）
 - **WezTerm** - ターミナルエミュレータ
 - **AeroSpace** - i3 風タイル型ウィンドウマネージャ
-- **Zsh** - シェル設定（エイリアス、fzf 連携等）
+- **Zsh** - シェル設定（エイリアス、fzf 連携、`pj` によるプロジェクトジャンプ等）
 - **Starship** - プロンプト設定
 - **Claude Code** - AI コーディングアシスタント設定
 
@@ -21,7 +21,7 @@ home-manager (Nix) への移行は段階的に進行中で、Phase 1 ([#51](http
 | Zsh / Git / Starship / direnv | home-manager (`programs.*`) |
 | Neovim / WezTerm / AeroSpace / Claude Code | home-manager (`mkOutOfStoreSymlink`) |
 | fzf | home-manager (`programs.fzf`)（zsh 統合自動有効化） |
-| cosign / cowsay / eza / gh / jq / lazygit / luacheck / railway / serie / shellcheck / stylua | home-manager (`home.packages`) |
+| cosign / cowsay / eza / fd / gh / jq / lazygit / luacheck / railway / serie / shellcheck / stylua | home-manager (`home.packages`) |
 | GUI / Cask アプリ (1Password / WezTerm 等) | Homebrew (`Brewfile`) |
 | プロジェクト固有のランタイム (ruby / node 等) | プロジェクト側 `flake.nix` + direnv（dotfiles では扱わない） |
 

--- a/home.nix
+++ b/home.nix
@@ -23,6 +23,7 @@
     cosign
     cowsay
     eza
+    fd
     gh
     imagemagick
     jq

--- a/zsh/zshrc-extra.sh
+++ b/zsh/zshrc-extra.sh
@@ -9,3 +9,15 @@
 cd() {
 	builtin cd "$@" && eza -l --icons --group-directories-first
 }
+
+# pj (project jump): ホームディレクトリ配下の git リポジトリのルートを fzf で選んで移動する。
+# 引数で検索起点となる ~/ 配下のディレクトリを指定できる（例: `pj work` → ~/work、無指定は ~/dev）。
+# fd で .git ディレクトリを列挙し、親（リポジトリルート）を抽出して候補にする。
+# fd は隠しファイル・.gitignore を既定で除外するため候補がノイズなく絞られる。
+pj() {
+	local base="$HOME/${1:-dev}"
+	local dir
+	[ -d "$base" ] || { echo "pj: no such directory: $base" >&2; return 1; }
+	dir=$(fd --type d --hidden '^\.git$' "$base" | sed 's|/\.git/*$||' | fzf) || return
+	cd "$dir" || return
+}


### PR DESCRIPTION
## 概要
- `~/` 配下から git リポジトリのルートを fzf で選んで移動する `pj` 関数を追加
- 候補抽出に `fd` を導入（`home.packages`）
- README のツール一覧・Zsh 説明を更新

## 背景・モチベーション
`~/dev/` 配下に個人開発プロジェクトを配置しているが、深い階層への `cd` 入力やプロジェクト間の切り替えが手間だった。既存の `dcd`（`find ~ -type d`）は HOME 全体を走査するため遅く、`.claude` や `node_modules` 等の隠しdirまで候補に出て絞り込めなかった。fd + fzf でリポジトリルートだけを高速に絞り込めるようにする。(#95)

## 変更の詳細
- `zsh/zshrc-extra.sh`: `pj` 関数を追加
  - `fd --type d --hidden '^\.git$'` で `.git` を列挙し、親（リポジトリルート）を抽出して fzf で選択
  - 引数で検索起点の `~/` 配下ディレクトリを指定可能（例: `pj work` → `~/work`、無指定は `~/dev`）
  - 存在しないディレクトリ指定時はエラー表示して中断
  - `fd` は隠しファイル・`.gitignore` を既定で除外するため候補がノイズなく絞られる
- `home.nix`: `fd` を `home.packages` に追加
- `README.md`: 管理対象ツール一覧に `fd` を追加、Zsh 説明に `pj` を追記

## 動作確認
- [x] `shellcheck zsh/zshrc-extra.sh` パス
- [x] `nix build .#homeConfigurations.komusan.activationPackage` パス
- [x] `home-manager switch` 後、`pj` で `~/dev` 配下のリポジトリルートが一覧表示され移動できることを確認
- [x] `pj work` で検索起点を変更できることを確認

## 注意事項・補足
- 段階的導入の第一歩。今後 `pj` の git リポジトリ限定 UI をベースに、fzf キーバインド（Ctrl-T / Alt-C）の `fd` 化なども検討予定
- `Closes #95`