### PR TITLE
feat: render-markdown.nvim を導入してバッファ内 Markdown レンダリングを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ home-manager (Nix) への移行は段階的に進行中で、Phase 1 ([#51](http
 | [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) | LSP 設定 | `plugins/lsp.lua` |
 | [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) | ステータスライン | `plugins/lualine.lua` |
 | [peek.nvim](https://github.com/toppair/peek.nvim) | Markdown プレビュー（mermaid 対応・要 Deno） | `plugins/peek.lua` |
+| [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) | Markdown をバッファ内でインラインレンダリング | `plugins/render-markdown.lua` |
 | [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) | ファイルエクスプローラー | `plugins/neo-tree.lua` |
 | [vim-rails](https://github.com/tpope/vim-rails) | Rails サポート | `plugins/ruby.lua` |
 | [vim-endwise](https://github.com/tpope/vim-endwise) | Ruby end 自動補完 | `plugins/ruby.lua` |

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -33,6 +33,7 @@
   "nvim-web-devicons": { "branch": "master", "commit": "746ffbb17975ebd6c40142362eee1b0249969c5c" },
   "peek.nvim": { "branch": "master", "commit": "5820d937d5414baea5f586dc2a3d912a74636e5b" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
+  "render-markdown.nvim": { "branch": "main", "commit": "f422cb5c6855f150e2ddcfaf44e7157b98b34f6a" },
   "rose-pine": { "branch": "main", "commit": "6a961effd67f6130d36df6d1c05c48c739796dd2" },
   "swenv.nvim": { "branch": "main", "commit": "4157de2619ec2e5c61c103fb6517845a0e04e558" },
   "tabset.nvim": { "branch": "main", "commit": "996f95e4105d053a163437e19a40bd2ea10abeb2" },

--- a/nvim/.config/nvim/lua/plugins/init.lua
+++ b/nvim/.config/nvim/lua/plugins/init.lua
@@ -7,6 +7,7 @@ require("lazy").setup({
   { import = "plugins.toggleterm" },
   { import = "plugins.alpha" },
   { import = "plugins.peek" },
+  { import = "plugins.render-markdown" },
   { import = "plugins.colorscheme" },
   { import = "plugins.lualine" },
   { import = "plugins.neo-tree" },

--- a/nvim/.config/nvim/lua/plugins/render-markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/render-markdown.lua
@@ -1,0 +1,40 @@
+return {
+  "MeanderingProgrammer/render-markdown.nvim",
+  ft = { "markdown" },
+  dependencies = {
+    "nvim-treesitter/nvim-treesitter",
+    "nvim-tree/nvim-web-devicons",
+  },
+  opts = {
+    -- 見出し: アイコン付き・フル幅背景・下線で階層を明確化
+    heading = {
+      sign = true,
+      width = "full",
+      border = true,
+      icons = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+    },
+    -- コードブロック: 枠付きボックス + 言語ラベルで HTML の <pre> 風に
+    code = {
+      sign = true,
+      style = "full",
+      width = "block",
+      border = "thick",
+      left_pad = 2,
+      right_pad = 2,
+      language_pad = 2,
+    },
+    -- 箇条書き: 階層ごとに記号を変える
+    bullet = {
+      icons = { "●", "○", "◆", "◇" },
+    },
+    -- チェックボックス
+    checkbox = {
+      checked = { icon = "󰱒 " },
+      unchecked = { icon = "󰄱 " },
+    },
+    -- テーブル: 角丸罫線でレンダリング表示に寄せる
+    pipe_table = {
+      preset = "round",
+    },
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -16,6 +16,8 @@ return {
       "python",
       "ruby",
       "eruby",
+      "markdown",
+      "markdown_inline",
     },
     highlight = { enable = true },
     indent = { enable = true },


### PR DESCRIPTION
## 概要
- Neovim に render-markdown.nvim を導入し、Markdown をバッファ内でインラインレンダリングできるようにした
- 見出し・コードブロック・テーブル・チェックボックス等を装飾し、HTML レンダリングに寄せた表示にした

## 背景・モチベーション
Markdown プレビューは peek.nvim（別ウィンドウ表示）に移行済みだが、バッファ内での構造の視認性は素の表示のままだった。render-markdown.nvim は編集画面上で直接装飾表示するため、プレビューを開かずに構造を把握しやすくなる（peek.nvim とは用途が異なり併用可能）。

Closes #93

## 変更の詳細
- `plugins/render-markdown.lua`（新規）: `ft = { "markdown" }` で markdown 時のみ遅延ロード。treesitter / web-devicons を依存に指定
  - 見出しはフル幅背景＋下線、コードブロックは枠付きボックス化（`style = "full"` / `border = "thick"`）、テーブルは角丸罫線、箇条書き・チェックボックスにアイコンを設定
- `plugins/init.lua`: `plugins.render-markdown` を登録
- `plugins/treesitter.lua`: `markdown` / `markdown_inline` パーサーを追加（レンダリングに必須）
- `lazy-lock.json`: render-markdown.nvim を追記
- `README.md`: プラグイン一覧を更新

## 動作確認
- [x] Markdown ファイルを開き、見出し・コードブロック・テーブル等がバッファ内で装飾表示されることを確認
- [x] 既存の peek.nvim プレビュー（`<leader>mp`）と共存できることを確認

## 注意事項・補足
- アイコン表示には Nerd Font が必要
- ターミナル版 Neovim の制約上、見出しの文字サイズ拡大はできないため、背景バー・下線・色で階層を表現している
