### PR TITLE
feat: lazydocker を導入して Docker を TUI で管理

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ home-manager (Nix) への移行は段階的に進行中で、Phase 1 ([#51](http
 | Zsh / Git / Starship / direnv | home-manager (`programs.*`) |
 | Neovim / WezTerm / AeroSpace / Claude Code | home-manager (`mkOutOfStoreSymlink`) |
 | fzf | home-manager (`programs.fzf`)（zsh 統合自動有効化） |
-| cosign / cowsay / eza / fd / gh / jq / lazygit / luacheck / railway / serie / shellcheck / stylua | home-manager (`home.packages`) |
+| cosign / cowsay / eza / fd / gh / jq / lazygit / lazydocker / luacheck / railway / serie / shellcheck / stylua | home-manager (`home.packages`) |
 | GUI / Cask アプリ (1Password / WezTerm 等) | Homebrew (`Brewfile`) |
 | プロジェクト固有のランタイム (ruby / node 等) | プロジェクト側 `flake.nix` + direnv（dotfiles では扱わない） |
 

--- a/docker/docker.nix
+++ b/docker/docker.nix
@@ -23,6 +23,7 @@
     docker-compose
     docker-buildx
     colima
+    lazydocker
   ];
 
   xdg.configFile = {


### PR DESCRIPTION
## 概要
- CLI ツールとして lazydocker を導入し、Docker コンテナ・イメージ・ログを TUI で管理できるようにした

## 背景・モチベーション
lazygit を導入済みで TUI ベースのワークフローに慣れている一方、Docker 操作は都度 CLI コマンドを実行しておりコンテナ状態やログの確認が煩雑だった。lazydocker により、コンテナ/イメージ/ボリューム/ログの確認・操作を一画面で完結できる。

Closes #94

## 変更の詳細
- `docker/docker.nix`: `home.packages` に `lazydocker` を追加（Docker 関連ツールと同じモジュールに集約）
- `README.md`: CLI ツール一覧に `lazydocker` を追記

## 動作確認
- [x] `home-manager build --flake .#komusan` が成功（lazydocker 0.25.2 を取得）

## 注意事項・補足
- ランタイム非管理方針には該当せず、CLI ツールとして `home.packages` で管理
- 利用するには `home-manager switch --flake .#komusan` の再適用が必要
